### PR TITLE
fix(format-entity): plain object detection

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-payload-cms",
   "description": "Source data from Payload CMS",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "main": "./dist/gatsby-node.js",
   "files": [

--- a/plugin/src/format-entity.ts
+++ b/plugin/src/format-entity.ts
@@ -1,5 +1,5 @@
 import { payloadFieldType } from "./payload-field-type"
-import { isObject } from "lodash"
+import { isPlainObject } from "lodash"
 
 interface IFormatEntry {
   data: { [key: string]: unknown }
@@ -54,7 +54,7 @@ export const parsePayloadResponse = (props: { [key: string]: any }) => {
 
     if (payloadFieldType(props[value]) === `other`) {
       // support groups
-      if (isObject(props[value])) {
+      if (isPlainObject(props[value])) {
         parsedProps[value] = parsePayloadResponse(props[value])
       } else {
         parsedProps[value] = props[value]

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -16,6 +16,7 @@ const config: GatsbyConfig = {
           `events`,
           `landing-pages`,
           { slug: `policies`, locales: [`en`, `fr_FR`], params: { [`where[_status][equals]`]: `published` } },
+          `logos`,
         ],
         globalTypes: [{ slug: `customers`, locales: [`en`, `fr_FR`] }, `statistics`],
         fallbackLocale: `en`,


### PR DESCRIPTION
The formatter is parsing regular array values into an object. e.g. `[ 'en', 'en_GB', 'en_US', 'fr_FR' ]` becomes `{ '0': 'en', '1': 'en_GB', '2': 'en_US', '3': 'fr_FR' }`.

This is not desired. It is caused by using the wrong function to detect a plain object.