### PR TITLE
feat(*): replace schema validation with customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ gatsby-types.d.ts
 !.yarn/versions
 
 .env
+sdl

--- a/README.md
+++ b/README.md
@@ -39,7 +39,29 @@ Simple config:
 More options:
 
 ```ts
-import Joi from "joi"
+const schemaCustomizations = `
+type Post implements Node {
+  id: ID!
+  _id: Int!
+  slug: String!
+  title: String!
+  author: Author @link(by: "name")
+  image: Asset @link
+}
+
+type Author implements Node {
+  id: ID!
+  _id: Int!
+  name: String!
+}
+
+type Asset implements Node & RemoteFile {
+  url: String!
+  alt: String!
+  width: Int!
+  height: Int!
+}
+`
 
 {
   resolve: `gatsby-source-payload-cms`,
@@ -49,28 +71,20 @@ import Joi from "joi"
       `events`,
       `landing-pages`,
       { slug: `policies`, locales: [`en`, `fr_FR`], params: { [`where[_status][equals]`]: `published` } },
-      {
-        slug: `testimonials`,
-        schema: Joi.object({
-          id: Joi.string(),
-          name: Joi.string(),
-          locales: Joi.array(),
-          jobTitle: Joi.string(),
-          quote: Joi.any(),
-          createdAt: Joi.string(),
-          updatedAt: Joi.string(),
-          companyName: Joi.string(),
-          logo: Joi.object(),
-        }),
-      },
     ],
     globalTypes: [{ slug: `customers`, locales: [`en`, `fr_FR`] }, `statistics`],
     fallbackLocale: `en`,
   },
+  /**
+   * Create schema customizations
+   *
+   * Optional. Passed to the `createTypes` action in createSchemaCustomization.
+   *
+   * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization
+   */
+  schemaCustomizations,
 },
 ```
-
-- Use `schema` to define a schema that entities must validate against in order to be included. For Payload CMS, this may be useful if relationships are not available (either because the related entity has been deleted or the depth parameter is not sufficient) in which case the value may be an id string rather than an object.
 
 ## Development
 

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -1,5 +1,5 @@
 import type { GatsbyNode } from "gatsby"
-import { NODE_TYPES } from "./constants"
+import type { IPluginOptionsInternal } from "./types"
 
 /**
  * By default Gatsby, infers the data types for each node. This can be sometimes brittle or lead to hard-to-debug errors.
@@ -13,41 +13,19 @@ import { NODE_TYPES } from "./constants"
  * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#explicitly-defining-data-types
  * @see https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/#createSchemaCustomization
  */
-export const createSchemaCustomization: GatsbyNode[`createSchemaCustomization`] = ({ actions }) => {
+export const createSchemaCustomization: GatsbyNode[`createSchemaCustomization`] = (
+  { actions },
+  pluginOptions: IPluginOptionsInternal
+) => {
   const { createTypes } = actions
 
-  /**
-   * Two things are happening here:
-   * - The `Post` and `Author` types are being explicitly defined with all their fields
-   * - The `author` field on the `Post` type is being linked to the `Author` type via a foreign-key relationship
-   * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#foreign-key-fields
-   */
-  createTypes(`
-    type ${NODE_TYPES.Post} implements Node {
-      id: ID!
-      _id: Int!
-      slug: String!
-      title: String!
-      author: ${NODE_TYPES.Author} @link(by: "name")
-      image: ${NODE_TYPES.Asset} @link
-    }
-
-    type ${NODE_TYPES.Author} implements Node {
-      id: ID!
-      _id: Int!
-      name: String!
-    }
-
-    type ${NODE_TYPES.Asset} implements Node & RemoteFile {
-      url: String!
-      alt: String!
-      width: Int!
-      height: Int!
-    }
-  `)
+  const schemaCustomizations = pluginOptions.schemaCustomizations || ``
 
   /**
    * You most often will use SDL syntax to define your data types. However, you can also use type builders for more advanced use cases
    * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#gatsby-type-builders
    */
+  if (schemaCustomizations) {
+    createTypes(schemaCustomizations)
+  }
 }

--- a/plugin/src/fetch.ts
+++ b/plugin/src/fetch.ts
@@ -18,7 +18,6 @@ export type CollectionOptions = {
   /** If locales are set, return an array of entities each with an additional `locale` key. */
   locales?: Array<string>
   params?: { [key: string]: unknown }
-  schema: any
 }
 
 export const fetchEntity = async (query: CollectionOptions, context) => {
@@ -68,7 +67,6 @@ export const fetchEntity = async (query: CollectionOptions, context) => {
             data: localizationResponse,
             locale,
             gatsbyNodeType: query.type,
-            schema: query.schema,
           },
           context
         )
@@ -86,7 +84,6 @@ export const fetchEntity = async (query: CollectionOptions, context) => {
           {
             data,
             gatsbyNodeType: query.type,
-            schema: query.schema,
           },
           context
         ),
@@ -173,7 +170,6 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
                 data: entry,
                 gatsbyNodeType: query.type,
                 locale,
-                schema: query.schema,
               },
               context
             )
@@ -215,7 +211,6 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
             {
               data: entry,
               gatsbyNodeType: query.type,
-              schema: query.schema,
             },
             context
           )

--- a/plugin/src/format-entity.ts
+++ b/plugin/src/format-entity.ts
@@ -5,7 +5,6 @@ interface IFormatEntry {
   data: { [key: string]: unknown }
   locale?: string
   gatsbyNodeType: string
-  schema?: any
 }
 
 export const parsePayloadResponse = (props: { [key: string]: any }) => {
@@ -65,14 +64,7 @@ export const parsePayloadResponse = (props: { [key: string]: any }) => {
   return parsedProps
 }
 
-export const formatEntity = ({ data, locale, gatsbyNodeType, schema }: IFormatEntry, context?: any) => {
-  if (schema) {
-    const { error } = schema.validate(data)
-    if (error) {
-      context.reporter.warn(`Schema for ${gatsbyNodeType} entity failed validation. Excluding ${data.id}.`)
-      return null
-    }
-  }
+export const formatEntity = ({ data, locale, gatsbyNodeType }: IFormatEntry, context?: any) => {
   const res = {
     ...parsePayloadResponse(data),
     gatsbyNodeType,

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -4,3 +4,6 @@ export { createSchemaCustomization } from "./create-schema-customization"
 export { onPluginInit } from "./on-plugin-init"
 export { pluginOptionsSchema } from "./plugin-options-schema"
 export { sourceNodes } from "./source-nodes"
+
+// Utils
+export { gatsbyNodeTypeName } from "./utils"

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -21,7 +21,6 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
           slug: Joi.string(),
           locales: Joi.array().items(Joi.string()),
           params: Joi.object(),
-          schema: Joi.any(),
         })
       )
     ),
@@ -46,5 +45,13 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     nodePrefix: Joi.string(),
     // Optional. Map Payload locales to different strings in the resulting nodes.
     nodeTransform: Joi.object(),
+    /**
+     * Create schema customizations
+     *
+     * Optional. Passed to the `createTypes` action in createSchemaCustomization.
+     *
+     * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization
+     */
+    schemaCustomizations: Joi.string(),
   })
 }

--- a/plugin/src/source-nodes.ts
+++ b/plugin/src/source-nodes.ts
@@ -6,7 +6,7 @@ import { createAxiosInstance } from "./axios-instance"
 import { fetchEntity, fetchEntities } from "./fetch"
 import { isString } from "./utils"
 import type { CollectionOptions } from "./fetch"
-import { camelCase, upperFirst } from "lodash"
+import { gatsbyNodeTypeName } from "./utils"
 
 let isFirstSource = true
 
@@ -153,7 +153,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async (gatsbyApi, pluginOp
   /**
    * Set a default prefix
    */
-  const prefix = pluginOptions.nodePrefix || `Payload`
+  const prefix = pluginOptions.nodePrefix
 
   /**
    * Iterate over the data and create nodes
@@ -162,7 +162,13 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async (gatsbyApi, pluginOp
     for (const collection of result) {
       nodeBuilder({
         gatsbyApi,
-        input: { type: `${prefix}${upperFirst(camelCase(collection.gatsbyNodeType))}`, data: collection },
+        input: {
+          type: gatsbyNodeTypeName({
+            payloadSlug: collection.gatsbyNodeType,
+            ...(isString(prefix) && { prefix: prefix as string }),
+          }),
+          data: collection,
+        },
       })
     }
   }
@@ -170,7 +176,13 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async (gatsbyApi, pluginOp
     for (const global of result) {
       nodeBuilder({
         gatsbyApi,
-        input: { type: `${prefix}${upperFirst(camelCase(global.gatsbyNodeType))}`, data: global },
+        input: {
+          type: gatsbyNodeTypeName({
+            payloadSlug: global.gatsbyNodeType,
+            ...(isString(prefix) && { prefix: prefix as string }),
+          }),
+          data: global,
+        },
       })
     }
   }

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -22,6 +22,7 @@ export type NodeBuilderInput =
 
 interface IPluginOptionsKeys {
   endpoint: string
+  schemaCustomizations?: string
 }
 
 /**

--- a/plugin/src/utils.ts
+++ b/plugin/src/utils.ts
@@ -1,5 +1,5 @@
 import fetch, { HeadersInit } from "node-fetch"
-import { isEmpty } from "lodash"
+import { camelCase, isEmpty, upperFirst } from "lodash"
 
 const headers = {
   "Content-Type": `application/json`,
@@ -31,3 +31,6 @@ export const fetchDataMessage = (url: string, serializedParams?: string): string
   }
   return message.join(` `)
 }
+
+export const gatsbyNodeTypeName = ({ payloadSlug, prefix = `Payload` }: { payloadSlug: string; prefix?: string }) =>
+  `${prefix}${upperFirst(camelCase(payloadSlug))}`


### PR DESCRIPTION
Replace the Schema validation function with the possibility to pass a GraphQL Schema Definition Language string to `createTypes` in Gatsby's `onSchemaCustomization`.

## Details

Schema validation introduced in https://github.com/thompsonsj/gatbsy-source-payload-cms/pull/8 was a way of avoiding build errors caused by Gatsby being unable to infer types.

An example of when this can happen is if a relation is deleted in Payload - instead of an object, an id string is returned. If other articles in the collection have objects on that field, Gatsby will struggle to infer types.

Schema validation excluded entities which didn't pass this validation. This was always a quick fix to get the build working again - it makes more sense to explicitly define types for Gatsby.