### PR TITLE
Revert "minor(*): remove payload response modification"

### DIFF
--- a/plugin/src/format-entity.ts
+++ b/plugin/src/format-entity.ts
@@ -1,4 +1,5 @@
-import { isFunction } from "lodash"
+import { payloadFieldType } from "./payload-field-type"
+import { isFunction, isPlainObject } from "lodash"
 
 interface IFormatEntry {
   data: { [key: string]: unknown }
@@ -6,9 +7,66 @@ interface IFormatEntry {
   gatsbyNodeType: string
 }
 
+export const parsePayloadResponse = (props: { [key: string]: any }) => {
+  const parsedProps: { [key: string]: any } = {}
+  Object.keys(props).forEach((value) => {
+    /**
+     * Serilaize Slate JSON
+     *
+     * There is no schema to interpret - it is not useful to
+     * query this object in GraphQL. Serialize it to a string
+     * so that it can be converted to JSON when needed in
+     * applications.
+     */
+    if (payloadFieldType(props[value]) === `richText`) {
+      parsedProps[value] = JSON.stringify(props[value])
+    }
+
+    /**
+     * Serilaize images
+     *
+     * Although Payload CMS images have a common schema to
+     * some extent, the sizes array will have different keys
+     * depending on the different image transformations applied.
+     *
+     * TODO create asset nodes and investigate Gatsby's CDN feature
+     */
+    if (payloadFieldType(props[value]) === `upload`) {
+      parsedProps[value] = JSON.stringify(props[value])
+    }
+
+    /**
+     * Serilaize block layouts
+     *
+     * There is no schema to interpret - it is not useful to
+     * query this object in GraphQL. Serialize it to a string
+     * so that it can be converted to JSON when needed in
+     * applications.
+     */
+    if (payloadFieldType(props[value]) === `blocks`) {
+      parsedProps[value] = JSON.stringify(props[value])
+    }
+
+    // support array
+    if (payloadFieldType(props[value]) === `array`) {
+      parsedProps[value] = props[value].map((block: any) => parsePayloadResponse(block))
+    }
+
+    if (payloadFieldType(props[value]) === `other`) {
+      // support groups
+      if (isPlainObject(props[value])) {
+        parsedProps[value] = parsePayloadResponse(props[value])
+      } else {
+        parsedProps[value] = props[value]
+      }
+    }
+  })
+  return parsedProps
+}
+
 export const formatEntity = ({ data, locale, gatsbyNodeType }: IFormatEntry, context?: any) => {
   const res = {
-    ...data,
+    ...parsePayloadResponse(data),
     gatsbyNodeType,
     ...(locale && { locale: locale }),
   }

--- a/plugin/src/format-entity.ts
+++ b/plugin/src/format-entity.ts
@@ -23,20 +23,7 @@ export const parsePayloadResponse = (props: { [key: string]: any }) => {
     }
 
     /**
-     * Serilaize images
-     *
-     * Although Payload CMS images have a common schema to
-     * some extent, the sizes array will have different keys
-     * depending on the different image transformations applied.
-     *
-     * TODO create asset nodes and investigate Gatsby's CDN feature
-     */
-    if (payloadFieldType(props[value]) === `upload`) {
-      parsedProps[value] = JSON.stringify(props[value])
-    }
-
-    /**
-     * Serilaize block layouts
+     * Serialize block layouts
      *
      * There is no schema to interpret - it is not useful to
      * query this object in GraphQL. Serialize it to a string

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -4,3 +4,6 @@ export { createSchemaCustomization } from "./create-schema-customization"
 export { onPluginInit } from "./on-plugin-init"
 export { pluginOptionsSchema } from "./plugin-options-schema"
 export { sourceNodes } from "./source-nodes"
+
+// Utils
+export { gatsbyNodeTypeName } from "./utils"

--- a/plugin/src/payload-field-type.ts
+++ b/plugin/src/payload-field-type.ts
@@ -1,0 +1,49 @@
+// TODO consider moving this to the Payload CMS api response,
+// where we know the fieldType.
+export const payloadFieldType = (
+  value: any
+): "upload" | "richText" | "array" | "block" | "blocks" | "polymorphic" | "other" => {
+  if (!value) {
+    return `other`
+  }
+  if (typeof value === `object` && `filename` in value) {
+    return `upload`
+  }
+  if (typeof value === `object` && isPayloadPolymorphic(value)) {
+    return `polymorphic`
+  }
+
+  if (isPayloadBlock(value)) {
+    return `block`
+  }
+  // only support arrays (strings can be passed as regular props)
+  if (value.constructor !== Array) {
+    return `other`
+  }
+  // an array of Payload CMS blocks has a `blockType` field
+  if (value.find((item) => typeof item === `object` && isPayloadBlock(item))) {
+    return `blocks`
+  }
+  // richText always has a top-level children key for each array item (check first only)
+  // eslint-disable-next-line no-prototype-builtins
+  if (value.find((item) => typeof item === `object` && item.hasOwnProperty(`children`))) {
+    return `richText`
+  }
+  // the Payload array field will contain other Payload fields
+  if (
+    value.every(
+      (item) => typeof item === `object` && Object.keys(item).find((key) => payloadFieldType(item[key])! == `other`)
+    )
+  ) {
+    return `array`
+  }
+  return `other`
+}
+
+const isPayloadBlock = (value: { [key: string]: any }) =>
+  // eslint-disable-next-line no-prototype-builtins
+  value.hasOwnProperty(`blockType`) && value.hasOwnProperty(`id`)
+
+const isPayloadPolymorphic = (value: { [key: string]: any }) =>
+  // eslint-disable-next-line no-prototype-builtins
+  value.hasOwnProperty(`relationTo`) && value.hasOwnProperty(`value`)

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv" // see https://github.com/motdotla/dotenv#how-d
 dotenv.config()
 import { isArray, isEmpty, isPlainObject } from "lodash"
 
-import { schemaCustomizations } from "./sdl/schema-customizations"
+import { testimonials } from "./sdl/testimonials"
 
 const localeMap = {
   en: `en`,
@@ -35,9 +35,9 @@ type Asset implements Node & RemoteFile {
 }
 `
 
-const allSchemaCustomizations = `
+const schemaCustomizations = `
 ${originalSchemaCustomizations}
-${schemaCustomizations}
+${testimonials}
 `
 
 const config: GatsbyConfig = {
@@ -65,7 +65,7 @@ const config: GatsbyConfig = {
               isPlainObject(localeMap) && !isEmpty(localeMap[locale]) ? localeMap[locale] : locale
             ),
         },
-        schemaCustomizations: allSchemaCustomizations,
+        schemaCustomizations,
       } satisfies IPluginOptions,
     },
     `gatsby-plugin-image`,

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv" // see https://github.com/motdotla/dotenv#how-d
 dotenv.config()
 import { isArray, isEmpty, isPlainObject } from "lodash"
 
-import { testimonials } from "./sdl/testimonials"
+import { schemaCustomizations } from "./sdl/schema-customizations"
 
 const localeMap = {
   en: `en`,
@@ -35,9 +35,9 @@ type Asset implements Node & RemoteFile {
 }
 `
 
-const schemaCustomizations = `
+const allSchemaCustomizations = `
 ${originalSchemaCustomizations}
-${testimonials}
+${schemaCustomizations}
 `
 
 const config: GatsbyConfig = {
@@ -65,7 +65,7 @@ const config: GatsbyConfig = {
               isPlainObject(localeMap) && !isEmpty(localeMap[locale]) ? localeMap[locale] : locale
             ),
         },
-        schemaCustomizations,
+        schemaCustomizations: allSchemaCustomizations,
       } satisfies IPluginOptions,
     },
     `gatsby-plugin-image`,


### PR DESCRIPTION
Reverts thompsonsj/gatbsy-source-payload-cms#18 with some customisation to remove JSON encoding of Payload `upload` field types.

This is restored because without it, we can't query rich text fields with GraphQL in Gatbsy.

For fields where we don't have control over the structure of the content, we are unable to create a query in GraphQL.

Some relevant discussions:

- https://github.com/payloadcms/payload/discussions/224
- https://stackoverflow.com/questions/37059523/graphql-get-all-fields-from-nested-json-object