### PR TITLE
feat(plugin-options-schema): hard limit

### DIFF
--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -21,6 +21,8 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
           slug: Joi.string(),
           locales: Joi.array().items(Joi.string()),
           params: Joi.object(),
+          /** Override limit in query params and disable paginated query */
+          limit: Joi.number(),
         })
       )
     ),
@@ -33,6 +35,8 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
           slug: Joi.string(),
           locales: Joi.array().items(Joi.string()),
           params: Joi.object(),
+          /** Override limit in query params and disable paginated query */
+          limit: Joi.number(),
         })
       )
     ),

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -60,10 +60,19 @@ const payloadLocaleMap = {
   sv_SE: `sv`,
 }
 
+const API_CALL_LIMIT = `true`
+
+const commonParams = {
+  params: {
+    depth: 10,
+  },
+  ...(API_CALL_LIMIT === `true` && { limit: 5 }),
+}
+
 const globalParams = {
   params: {
+    ...commonParams.params,
     [`where[_status][equals]`]: `published`,
-    depth: 10,
   },
 }
 
@@ -79,16 +88,28 @@ const config: GatsbyConfig = {
       options: {
         endpoint: process.env.PAYLOAD_BASE_URL,
         collectionTypes: [
-          `events`,
-          `landing-pages`,
+          {
+            slug: `events`,
+            ...commonParams,
+          },
+          {
+            slug: `landing-pages`,
+            ...commonParams,
+          },
           {
             slug: `policies`,
             locales: payloadLocales,
-            params: { [`where[_status][equals]`]: `published` },
+            ...globalParams,
           },
-          `testimonials`,
-          { slug: `localized-testimonials`, locales: payloadLocales },
-          `logos`,
+          {
+            slug: `testimonials`,
+            ...commonParams,
+          },
+          { slug: `localized-testimonials`, locales: payloadLocales, ...commonParams },
+          {
+            slug: `logos`,
+            ...commonParams,
+          },
         ],
         globalTypes: [
           { slug: `customers`, locales: payloadLocales, ...globalParams },


### PR DESCRIPTION
Add a hard limit option that can be set on each collection/global.

Useful for testing/development: limit the number of results.