### PR TITLE
fix(*): remove schema customization option

### DIFF
--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -19,7 +19,7 @@ export const createSchemaCustomization: GatsbyNode[`createSchemaCustomization`] 
 ) => {
   const { createTypes } = actions
 
-  const schemaCustomizations = [pluginOptions.schemaCustomizations || ``]
+  const schemaCustomizations = []
 
   if (pluginOptions.imageCdn) {
     schemaCustomizations.push(`
@@ -36,7 +36,7 @@ export const createSchemaCustomization: GatsbyNode[`createSchemaCustomization`] 
    * You most often will use SDL syntax to define your data types. However, you can also use type builders for more advanced use cases
    * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#gatsby-type-builders
    */
-  if (schemaCustomizations) {
+  if (schemaCustomizations.length > 0) {
     createTypes(schemaCustomizations)
   }
 }

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -68,14 +68,6 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     nodePrefix: Joi.string(),
     // Optional. Map Payload locales to different strings in the resulting nodes.
     nodeTransform: Joi.object(),
-    /**
-     * Create schema customizations
-     *
-     * Optional. Passed to the `createTypes` action in createSchemaCustomization.
-     *
-     * @see https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization
-     */
-    schemaCustomizations: Joi.string(),
     // Optional. Create local file nodes for upload collections.
     localFiles: Joi.boolean(),
     // Optional. Create Gatsby Image CDN asset nodes for upload collections.

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -130,7 +130,6 @@ const config: GatsbyConfig = {
               isPlainObject(localeMap) && !isEmpty(localeMap[locale]) ? localeMap[locale] : locale
             ),
         },
-        schemaCustomizations: allSchemaCustomizations,
       } satisfies IPluginOptions,
     },
     `gatsby-plugin-image`,

--- a/site/gatsby-node.ts
+++ b/site/gatsby-node.ts
@@ -1,0 +1,29 @@
+import type { GatsbyNode } from "gatsby"
+import { schemaCustomizations } from "./sdl/schema-customizations"
+
+export const createSchemaCustomization: GatsbyNode[`createSchemaCustomization`] = ({ actions }) => {
+  const { createTypes } = actions
+
+  const originalSchemaCustomizations = `
+    type Post implements Node {
+      id: ID!
+      _id: Int!
+      slug: String!
+      title: String!
+      author: Author @link(by: "name")
+      image: Asset @link
+    }
+
+    type Author implements Node {
+      id: ID!
+      _id: Int!
+      name: String!
+    }
+    `
+
+  const allSchemaCustomizations = `
+    ${originalSchemaCustomizations}
+    ${schemaCustomizations}
+    `
+  createTypes(allSchemaCustomizations)
+}


### PR DESCRIPTION
The `schemaCustomizations` option doesn't make any sense. `export const createSchemaCustomization` in `gatsby-node` on Gatsby installations is the best way to add schema customizations.