### PR TITLE
fix(source-nodes): ensure height and width are integers

### DIFF
--- a/plugin/src/source-nodes.ts
+++ b/plugin/src/source-nodes.ts
@@ -314,8 +314,8 @@ export function createAssetNode(context: SourceNodesArgs, data: any, relationshi
     /**
      * If you don't know the width and height of the image, use: https://github.com/nodeca/probe-image-size
      */
-    width: data.width,
-    height: data.height,
+    width: Math.round(data.width),
+    height: Math.round(data.height),
     // placeholderUrl: `${data.url}&w=%width%&h=%height%`,
     relationships,
     alt: data.alt || ``,

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -118,6 +118,7 @@ const config: GatsbyConfig = {
           { slug: `ats`, locales: payloadLocales, ...globalParams },
         ],
         uploadTypes: [
+          { slug: `logo-images`, ...commonParams, imageSize: `logo` },
           { slug: `marketing-site-images`, ...commonParams, imageSize: `desktop` },
           { slug: `media`, ...commonParams },
         ],


### PR DESCRIPTION
Asset nodes can be created with float values for height and width. In this case, logo images are trimmed using https://sharp.pixelplumbing.com/api-resize#trim, and this results in float values for height and width (e.g. `30.77`).

This is incompatible with Gatsby's GraphQL schema which expects an integer for both width and height.

Ensure we don't get GraphQL schema errors in this use case.