### PR TITLE
feat(*): repopulate parameter

### DIFF
--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -31,6 +31,9 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
           params: Joi.object(),
           /** Override limit in query params and disable paginated query */
           limit: Joi.number(),
+          /** Repopulate results with a query on each result. Use with caution - can significantly increase the number of API calls. Included to get around an issue where the depth parameter is not always respected on paginated queries. */
+          /* Currently only supported for queries with locales */
+          repopulate: Joi.boolean(),
         })
       )
     ),

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -16,15 +16,23 @@ export interface IPayloadGlobalApiResponse extends IPayloadApiResponse {
   globalType: string
 }
 
+export type LocaleString = string
+
+export type LocaleObject = {
+  locale: string,
+  params: { [key: string]: unknown }
+}
+
 export type NodeBuilderInput =
   | { type: typeof NODE_TYPES.Author; data: IAuthorInput }
   | { type: string; data: IPayloadGlobalApiResponse }
 
 export interface ICollectionTypeObject {
   slug: string
-  locales?: Array<string>
+  locales?: Array<LocaleString> | Array<LocaleObject>
   params?: { [key: string]: string }
   limit?: number
+  repopulate?: boolean
 }
 
 export interface IUploadTypeObject extends ICollectionTypeObject {

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -105,6 +105,7 @@ const config: GatsbyConfig = {
               }
             }),
             ...commonParams,
+            repopulate: true,
           },
         ],
         globalTypes: [


### PR DESCRIPTION
Despite using the depth parameter, Lexical rich text relationship nodes are not populated with paginated queries. e.g. `https://yourapp.payloadcms.app/api/posts`. However, when fetching individual articles the relationships are populated.

To get around this issue, add a `repopulate` option to collections. Note that this is only supported when querying locales. The logic is a bit messy and a refactor is needed, but keeping it as-is for now in case this is not expected behaviour and gets resolved through Payload CMS.

See discussion at https://discord.com/channels/967097582721572934/1163849822382596137.