### PR TITLE
refactor(pluginoptions): rename accessUserSlug

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,24 @@ Simple config:
 },
 ```
 
-More options:
+### Options
+
+#### Required
+
+| Option | Example value | Description |
+| - | - | - |
+| `endpoint` | `https://yourapp.payload.app/api/` | Endpoint to the API for your Payload CMS installation. |
+
+#### Optional
+
+| Option | Example value | Description |
+| - | - | - |
+| `accessToken` | `44289e4c-55a7-4f67-de6a-e5d9423e595e` | API key. See [Authenticating via API Key - Payload CMS](https://payloadcms.com/docs/authentication/config#api-keys). |
+| `accessCollectionSlug` | `users` | Collection slug for API key enabled collection. See [Authenticating via API Key - Payload CMS](https://payloadcms.com/docs/authentication/config#api-keys). If blank, will default to `users` |
+| `imageCdn` | `false` | Adds a `gatsbyImageCdn` field to upload type nodes. See Netlify docs at [Gatsby Image CDN on Netlify](https://github.com/netlify/netlify-plugin-gatsby/blob/main/docs/image-cdn.md) |
+| `localFiles` | `false` | Download files in upload type nodes and create file nodes. Uses [createRemoteFileNode - gatsby-source-filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/#createremotefilenode). |
+
+#### Example
 
 ```ts
 {
@@ -62,12 +79,9 @@ More options:
 },
 ```
 
-Authorization is based on API keys. See [Authenticating via API Key | Authentication Config | Payload CMS](https://payloadcms.com/docs/authentication/config#api-keys).
-
 ## Points to note
 
 - `gatsbyNodeType` is a reserved key for API responses. If you have a Payload field with this name, it will be overwritten.
-- If using Gatsby Image CDN, a `gatsbyImageCdn` field will be added to upload type nodes.
 
 ## Gatsby Image CDN support
 

--- a/plugin/src/axios-instance.ts
+++ b/plugin/src/axios-instance.ts
@@ -36,12 +36,13 @@ const throttlingInterceptors = (axiosInstance, maxParallelRequests) => {
 }
 
 export const createAxiosInstance = (pluginConfig) => {
-  const { maxParallelRequests = Number.POSITIVE_INFINITY, accessToken, accessUserSlug, apiURL } = pluginConfig
+  const { maxParallelRequests = Number.POSITIVE_INFINITY, accessToken, accessCollectionSlug, apiURL } = pluginConfig
 
   const headers: { [key: string]: string } = {}
 
-  if (accessToken && accessUserSlug) {
-    headers.authorization = `${accessUserSlug} API-Key ${accessToken}`
+  if (accessToken) {
+    console.log(`${accessCollectionSlug || 'users'} API-Key ${accessToken}`)
+    headers.Authorization = `${accessCollectionSlug || 'users'} API-Key ${accessToken}`
   }
 
   const instance = axios.create({

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -88,8 +88,8 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     ),
     // Optional. Access token. Use if your API is protected.
     accessToken: Joi.string(),
-    // Optional. User slug. Use if your API is protected.
-    accessUserSlug: Joi.string(),
+    // Optional. Collection slug where API key access available. Use if your API is protected. If blank, this is set to `users`.
+    accessCollectionSlug: Joi.string(),
     // Optional. Throttle parallel requests.
     maxParallelRequests: Joi.number(),
     // Optional. Retry requests using https://www.npmjs.com/package/axios-retry.

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -77,9 +77,11 @@ const config: GatsbyConfig = {
     // Load the plugin with its options
     {
       resolve: `gatsby-source-payload-cms`,
+
       // You can pass any serializable options to the plugin
       options: {
         endpoint: process.env.PAYLOAD_BASE_URL,
+        accessToken: process.env.PAYLOAD_CMS_ACCESS_TOKEN,
         retries: 3,
         localFiles: false,
         imageCdn: true,


### PR DESCRIPTION
Rename `accessUserSlug` to `accessCollectionSlug`. More appropriate name. Make this optional - fallback to `users` if not set which is likely to be the value in most cases. Payload CMS adds this collection by default.