### PR TITLE
refactor(formatentity)!: node transform fn runs on whole data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ Simple config:
 | - | - | - |
 | `accessToken` | `44289e4c-55a7-4f67-de6a-e5d9423e595e` | API key. See [Authenticating via API Key - Payload CMS](https://payloadcms.com/docs/authentication/config#api-keys). |
 | `accessCollectionSlug` | `users` | Collection slug for API key enabled collection. See [Authenticating via API Key - Payload CMS](https://payloadcms.com/docs/authentication/config#api-keys). If blank, will default to `users` |
-| `imageCdn` | `false` | Adds a `gatsbyImageCdn` field to upload type nodes. See Netlify docs at [Gatsby Image CDN on Netlify](https://github.com/netlify/netlify-plugin-gatsby/blob/main/docs/image-cdn.md) |
+| `imageCdn` | `false` | Adds a `gatsbyImageCdn` field to upload type nodes. [More](/docs/image-cdn.md). |
 | `localFiles` | `false` | Download files in upload type nodes and create file nodes. Uses [createRemoteFileNode - gatsby-source-filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/#createremotefilenode). |
 | `collectionTypes` | `['posts']` | Specifiy collections to retrive along with any collection-specific options. [More](#collection-types). |
 | `globalTypes` | `['nav']` | Specifiy globals to retrive along with any global-specific options. [More](#global-types). |
+| `nodeTransform` | `{ ['myField'] => (myField) => transformMyField(myField) }` | Incorporate functions to transform the value returned for a given Payload field. [More](#node-transform) |
 
 ### Example
 
@@ -135,126 +136,35 @@ Use `object` values for further control over how the global is retrieved.
 | `params` | `{ depth: 4 }` | Pass query parameters to REST API call. |
 | `apiPath` | `header/icu` | Custom API path. Useful when using [custom endpoints](https://payloadcms.com/docs/rest-api/overview#custom-endpoints). |
 
+### Node transform
 
-## Points to note
-
-- `gatsbyNodeType` is a reserved key for API responses. If you have a Payload field with this name, it will be overwritten.
-
-## Gatsby Image CDN support
-
-Gatsby Image CDN support is available for [Payload Upload collections](https://payloadcms.com/docs/upload/overview).
-
-Define your Upload collection slugs and enable the feature:
+A function can be defined in the plugin options to transform field values in a Payload API response before creating a Gatsby node.
 
 ```ts
 {
-  resolve: `gatsby-source-payload-cms`,
-  options: {
-    endpoint: `https://yourapp.payload.app/api/`,
-    imageCdn: true,
-    uploadTypes: [
-      `headshots`,
-      `logo-images`,
-    ],
-  },
-},
-```
-
-`Asset` nodes will be created for each upload. A `gatsbyImageCdn` field is added to each Upload node that links to the appropriate `Asset` node.
-
-An example GraphQL query on all Upload nodes:
-
-```graphql
-{
-  allPayloadHeadshots {
-    nodes {
-      url
-      gatsbyImageCdn {
-        publicUrl
-        gatsbyImage(height: 600)
+  // ...
+  nodeTransform: (data) => {
+    if ('locale' in data) {
+      return {
+        ...data,
+        gatsbyNodeLocale: data.locale,
       }
     }
-  }
+    return data
+  },
+  // ...
 }
 ```
 
-### Relationships
+Node transform functions run before [reserved properties](#reserved-properties) are set. This allows you to access any information that may be overwritten by reserved properties: e.g. a `locale` field.
 
-In the previous example, `PayloadHeadshots` (sourced from a `headshots` upload collection in Payload CMS) is a made available to Gatsby with a `gatsbyImageCdn` field that contains the corresponding Gatsby Image CDN asset.
+## Reserved properties
 
-However, the `gatsbyImageCdn` field will not be available when `PayloadHeadshots` is made available through a relationship. For example, a `PayloadTestimonials` type might include a `PayloadHeadshots` type as a relationship.
+- `gatsbyNodeType` is a reserved key for API responses. If you have a Payload field with this name, it will be overwritten.
+- `locale` is set if the `locales` option is defined for a given collection/global.
 
-There are two ways to make the `gatsbyImageCdn` field available in this scenario.
+For upload collections:
 
-#### Resolvers
+- `gatsbyImageCdn` contains the query for image CDN support if the `imageCdn` option is set on plugin options.
+- `payloadImageSize` reports the image size (`string`) that has been set in the config for an upload collection.
 
-Add a custom resolver that creates a new field linking to the upload collection Gatsby GraphQL type.
-
-```ts
-export const createResolvers: GatsbyNode['createResolvers'] = async ({
-  createResolvers,
-}) => {
-  createResolvers({
-    PayloadTestimonials: {
-      headshotCdn: {
-        type: 'PayloadHeadshots',
-        resolve: (source: any, args: any, context: any, info: any) =>
-          source.headshot
-            ? context.nodeModel.findOne({
-                type: 'PayloadHeadshots',
-                query: {
-                  filter: { _id: { eq: source.headshot.id } },
-                },
-              }) || null
-            : null,
-      },
-    },
-  });
-};
-```
-
-This additional field can now be queried.
-
-```graphql
-testimonial: payloadTestimonials() {
-  companyName
-  jobTitle
-  name
-  quote
-  headshot: headshotCdn {
-    gatsbyImageCdn {
-      ...HeadshotQuery
-    }
-  }
-}
-```
-
-#### Relationships field
-
-For situations where adding custom resolvers can be complicated, a `relationships` field is made available on `Asset` nodes.
-
-This can be used to query assets or determine where an asset is used.
-
-This is particularly useful for [block fields](https://payloadcms.com/docs/fields/blocks) or deeply nested upload relationships. In this situation, custom resolvers are complicated to create and maintain.
-
-```ts
-{
-  "relationships": [
-    "events.645e126f26a303cb2e24f857.layout[2].image.id",
-    "events.646c92fad358f527dfb44142.layout[2].image.id",
-    "events.6478badec093e67255801925.layout[2].image.id",
-    "events.64aeb9db71885e8c72c02327.layout[2].image.id"
-  ]
-}
-```
-
-Example query:
-
-```graphql
-image_textWithImage: asset(
-  relationships: { eq: "global.textWithImage.image.id" }
-) {
-  alt
-  gatsbyImage(width: 2048, quality: 85)
-}
-```

--- a/docs/image-cdn.md
+++ b/docs/image-cdn.md
@@ -1,0 +1,118 @@
+# Gatsby Image CDN support
+
+Gatsby Image CDN support is available for [Payload Upload collections](https://payloadcms.com/docs/upload/overview).
+
+Define your Upload collection slugs and enable the feature:
+
+```ts
+{
+  resolve: `gatsby-source-payload-cms`,
+  options: {
+    endpoint: `https://yourapp.payload.app/api/`,
+    imageCdn: true,
+    uploadTypes: [
+      `headshots`,
+      `logo-images`,
+    ],
+  },
+},
+```
+
+`Asset` nodes will be created for each upload. A `gatsbyImageCdn` field is added to each Upload node that links to the appropriate `Asset` node.
+
+An example GraphQL query on all Upload nodes:
+
+```graphql
+{
+  allPayloadHeadshots {
+    nodes {
+      url
+      gatsbyImageCdn {
+        publicUrl
+        gatsbyImage(height: 600)
+      }
+    }
+  }
+}
+```
+
+## Relationships
+
+In the previous example, `PayloadHeadshots` (sourced from a `headshots` upload collection in Payload CMS) is a made available to Gatsby with a `gatsbyImageCdn` field that contains the corresponding Gatsby Image CDN asset.
+
+However, the `gatsbyImageCdn` field will not be available when `PayloadHeadshots` is made available through a relationship. For example, a `PayloadTestimonials` type might include a `PayloadHeadshots` type as a relationship.
+
+There are two ways to make the `gatsbyImageCdn` field available in this scenario.
+
+### Resolvers
+
+Add a custom resolver that creates a new field linking to the upload collection Gatsby GraphQL type.
+
+```ts
+export const createResolvers: GatsbyNode['createResolvers'] = async ({
+  createResolvers,
+}) => {
+  createResolvers({
+    PayloadTestimonials: {
+      headshotCdn: {
+        type: 'PayloadHeadshots',
+        resolve: (source: any, args: any, context: any, info: any) =>
+          source.headshot
+            ? context.nodeModel.findOne({
+                type: 'PayloadHeadshots',
+                query: {
+                  filter: { _id: { eq: source.headshot.id } },
+                },
+              }) || null
+            : null,
+      },
+    },
+  });
+};
+```
+
+This additional field can now be queried.
+
+```graphql
+testimonial: payloadTestimonials() {
+  companyName
+  jobTitle
+  name
+  quote
+  headshot: headshotCdn {
+    gatsbyImageCdn {
+      ...HeadshotQuery
+    }
+  }
+}
+```
+
+### Relationships field
+
+For situations where adding custom resolvers can be complicated, a `relationships` field is made available on `Asset` nodes.
+
+This can be used to query assets or determine where an asset is used.
+
+This is particularly useful for [block fields](https://payloadcms.com/docs/fields/blocks) or deeply nested upload relationships. In this situation, custom resolvers are complicated to create and maintain.
+
+```ts
+{
+  "relationships": [
+    "events.645e126f26a303cb2e24f857.layout[2].image.id",
+    "events.646c92fad358f527dfb44142.layout[2].image.id",
+    "events.6478badec093e67255801925.layout[2].image.id",
+    "events.64aeb9db71885e8c72c02327.layout[2].image.id"
+  ]
+}
+```
+
+Example query:
+
+```graphql
+image_textWithImage: asset(
+  relationships: { eq: "global.textWithImage.image.id" }
+) {
+  alt
+  gatsbyImage(width: 2048, quality: 85)
+}
+```

--- a/plugin/src/format-entity.ts
+++ b/plugin/src/format-entity.ts
@@ -8,22 +8,22 @@ interface IFormatEntry {
 }
 
 export const formatEntity = ({ data, locale, gatsbyNodeType, payloadImageSize }: IFormatEntry, context?: any) => {
-  const res = {
-    ...data,
-    gatsbyNodeType,
-    ...(locale && { locale: locale }),
-    payloadImageSize,
-  }
   if (!context.pluginOptions.nodeTransform) {
-    return res
+    return addReservedProperties({data, locale, gatsbyNodeType, payloadImageSize})
   }
-  const transformedRes: { [key: string]: any } = {}
-  Object.keys(res).forEach((value) => {
-    if (isFunction(context.pluginOptions.nodeTransform[value])) {
-      transformedRes[value] = context.pluginOptions.nodeTransform[value](res[value])
-    } else {
-      transformedRes[value] = res[value]
-    }
-  })
-  return transformedRes
+  let transformedRes: { [key: string]: any } = {}
+  if (isFunction(context.pluginOptions.nodeTransform)) {
+    transformedRes = context.pluginOptions.nodeTransform(data)
+  } else {
+    transformedRes = data
+  }
+  return addReservedProperties({data: transformedRes, locale, gatsbyNodeType, payloadImageSize})
 }
+
+const addReservedProperties = ({ data, locale, gatsbyNodeType, payloadImageSize }: IFormatEntry) => ({
+  ...data,
+  id: data.id, // added to pass typing check
+  gatsbyNodeType,
+  ...(locale && { locale: locale }),
+  payloadImageSize,
+})

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -100,7 +100,7 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     // Optional. Add a prefix to Gatsby nodes. Default: Payload.
     nodePrefix: Joi.string(),
     // Optional. Map Payload locales to different strings in the resulting nodes.
-    nodeTransform: Joi.object(),
+    nodeTransform: Joi.function(),
     // Optional. Create local file nodes for upload collections.
     localFiles: Joi.boolean(),
     // Optional. Create Gatsby Image CDN asset nodes for upload collections.

--- a/site/gatsby-config.ts
+++ b/site/gatsby-config.ts
@@ -1,5 +1,5 @@
 import type { GatsbyConfig } from "gatsby"
-import type { IPluginOptions } from "plugin"
+import type { IPluginOptions } from "../plugin/src/types"
 import * as dotenv from "dotenv" // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
 dotenv.config()
 import { isArray, isEmpty, isPlainObject } from "lodash"
@@ -57,7 +57,7 @@ const API_CALL_LIMIT = `true`
 
 const commonParams = {
   params: {
-    depth: 10,
+    depth: `10`,
   },
   ...(API_CALL_LIMIT === `true` && { limit: 1000 }),
 }
@@ -87,6 +87,11 @@ const config: GatsbyConfig = {
         imageCdn: true,
         baseUrl: process.env.PAYLOAD_CDN_URL,
         collectionTypes: [
+          {
+            slug: `events`,
+            locales: payloadLocales,
+            ...commonParams,
+          },
           {
             slug: `testimonials`,
             ...commonParams,
@@ -124,13 +129,14 @@ const config: GatsbyConfig = {
           { slug: `media`, ...commonParams },
         ],
         fallbackLocale: `en`,
-        nodeTransform: {
-          locale: (locale) => (isPlainObject(localeMap) && !isEmpty(localeMap[locale]) ? localeMap[locale] : locale),
-          locales: (locales) =>
-            isArray(locales) &&
-            locales.map((locale) =>
-              isPlainObject(localeMap) && !isEmpty(localeMap[locale]) ? localeMap[locale] : locale
-            ),
+        nodeTransform: (data) => {
+          if ('locale' in data) {
+            return {
+              ...data,
+              gatsbyNodeLocale: data.locale,
+            }
+          }
+          return data
         },
         // schemaCustomizations: allSchemaCustomizations,
       } satisfies IPluginOptions,


### PR DESCRIPTION
Breaking change if using the `nodeTransform` option.

`nodeTransform` is now a function that accepts the data from Payload as an argument and expects this data to be returned with any adjustments. An example is given in the docs where the `locale` field is intercepted and copied to another field name before it gets overwritten be reserved properties.

Documentation relevant to this change. has been re-organised and improved.