### PR TITLE
fix(sourcenodes): remove encoding of image urls

### DIFF
--- a/plugin/src/source-nodes.ts
+++ b/plugin/src/source-nodes.ts
@@ -261,7 +261,7 @@ export async function createLocalFileNode(
   const { createNode, createNodeField } = context.actions
   const { getCache } = context
   const baseUrl = (get(context, `pluginOptions.baseUrl`, ``) as string).replace(/\/$/, ``)
-  const url = encodeURI(payloadImageUrl(data, data.payloadImageSize, baseUrl)) as string
+  const url = payloadImageUrl(data, data.payloadImageSize, baseUrl) as string
 
   const fileNode = await createRemoteFileNode({
     url,
@@ -287,7 +287,7 @@ export function createAssetNode(context: SourceNodesArgs, data: any, relationshi
   const id = context.createNodeId(`${NODE_TYPES.Asset}-${data.url}`)
   const baseUrl = (get(context, `pluginOptions.baseUrl`, ``) as string).replace(/\/$/, ``)
   const image = payloadImage(data, data.payloadImageSize) 
-  const url = encodeURI(payloadImageUrl(data, data.payloadImageSize, baseUrl)) as string
+  const url = payloadImageUrl(data, data.payloadImageSize, baseUrl) as string
   const relationships: Array<string> = Object.keys(
     pickBy(relationshipIds, (value) => {
       return value === data.id


### PR DESCRIPTION
Payload CMS 3 seems to encode file URLs. Remove URL encoding to ensure that file URLs are not double encoded.

Note that this pull request represents the first change for the plugin tested against Payload CMS 3. A branch has been created to represent the state of the plugin before this change at https://github.com/thompsonsj/gatbsy-source-payload-cms/tree/payload-2.