### PR TITLE
fix(pluginoptionsschema): allow empty string nodePrefix

### DIFF
--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -98,7 +98,7 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     retries: Joi.number(),
     fallbackLocale: Joi.string(),
     // Optional. Add a prefix to Gatsby nodes. Default: Payload.
-    nodePrefix: Joi.string(),
+    nodePrefix: Joi.string().allow(''),
     // Optional. Map Payload locales to different strings in the resulting nodes.
     nodeTransform: Joi.function(),
     // Optional. Create local file nodes for upload collections.


### PR DESCRIPTION
Should be allowed to set an empty `nodePrefix`. Without this change, Gatsby `dev` fails at validation:

```
success load gatsby config - 0.021s

 ERROR #11331  API.NODE.VALIDATION

Invalid plugin options for "gatsby-source-payload-cms":

- "nodePrefix" is not allowed to be empty

not finished load plugins - 0.279s
```