### PR TITLE
fix(types): params optional on LocaleObject

### DIFF
--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -20,7 +20,7 @@ export type LocaleString = string
 
 export type LocaleObject = {
   locale: string,
-  params: { [key: string]: unknown }
+  params?: { [key: string]: unknown }
 }
 
 export type NodeBuilderInput =


### PR DESCRIPTION
## Summary
- Makes `params` optional on `LocaleObject` in `plugin/src/types.ts`, since callers can omit it.

## Test plan
- [ ] Type-check consumers that construct `LocaleObject` without `params`