### PR TITLE
fix(plugin): stop small page sizes from silently exploding request counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Simple config:
 | `collectionTypes` | `['posts']` | Specifiy collections to retrive along with any collection-specific options. [More](#collection-types). |
 | `globalTypes` | `['nav']` | Specifiy globals to retrive along with any global-specific options. [More](#global-types). |
 | `nodeTransform` | `{ ['myField'] => (myField) => transformMyField(myField) }` | Incorporate functions to transform the value returned for a given Payload field. [More](#node-transform) |
+| `maxParallelRequests` | `10` | Cap requests in flight at once. Defaults to `10`. [More](#performance-maxparallelrequests-and-limit). |
+| `retries` | `3` | Retry failed requests using [axios-retry](https://www.npmjs.com/package/axios-retry). |
 
 ### Example
 
@@ -81,6 +83,23 @@ Simple config:
   },
 },
 ```
+
+### Performance: `maxParallelRequests` and `limit`
+
+`maxParallelRequests` caps how many requests are in flight at once (default:
+`10`). This trades wall-clock sourcing time against load on the origin API and
+the machine running the build:
+
+- Raising `maxParallelRequests` fetches more pages concurrently, finishing
+  faster but increasing load on the Payload API and memory use during the
+  build.
+- Lowering it reduces that load, at the cost of a longer sourcing step.
+- A collection's page size (`limit`) interacts with this: a smaller page size
+  means more total pages/requests for the same collection, so lowering
+  `limit` while also lowering `maxParallelRequests` compounds into a much
+  longer build — the plugin logs a warning if a collection's page count looks
+  unexpectedly large, and periodic progress (every 10 pages) while fetching,
+  so a slow sourcing step is diagnosable without reading the plugin's source.
 
 ### Collection Types
 
@@ -182,7 +201,22 @@ See [REST API | Payload CMS](https://payloadcms.com/docs/rest-api/overview) for 
 
 ### `limit`
 
-Limit number of documents retrieved.
+> **`limit` sets the Payload REST API's page size — it is NOT a cap on the total
+> number of documents retrieved.** It maps directly onto Payload's own `limit`
+> query parameter (documents per page), and setting it also disables this
+> plugin's automatic pagination, so only a single page of that size is fetched.
+>
+> If you want to cap the *total* number of documents fetched for a collection
+> (e.g. for a fast local/dev build, or a quick smoke test), use
+> [`maxDocs`](#maxdocs) instead — setting `limit` to a small value fetches
+> exactly that many documents and no more (pagination is disabled), which
+> silently truncates a large collection rather than sourcing everything.
+>
+> **Do not set `limit` inside `params`** — that's Payload's own REST API query
+> parameter of the same name, and it bypasses this plugin's pagination
+> controls entirely. A small page size set that way, on a large collection,
+> multiplies the number of requests needed to fetch it (the plugin warns via
+> the Gatsby `reporter` if this happens). The same applies to `uploadTypes`.
 
 ```ts
 {
@@ -190,6 +224,7 @@ Limit number of documents retrieved.
   collectionTypes: [
     {
       slug: 'posts',
+      // Fetches (and paginates through) the collection 100 documents at a time.
       limit: 100,
     },
   ]
@@ -197,9 +232,14 @@ Limit number of documents retrieved.
 }
 ```
 
-### Repopulate
+### `maxDocs`
 
-Run a single document query for every document retrieved.
+Stop paginating once at least this many documents have been fetched for the
+collection (per locale, if `locales` is set). Unlike `limit`, this does not
+change the API page size — it just stops requesting further pages once
+enough documents have come back. This is the option to reach for when you
+actually want to cap the total number of documents fetched, e.g. for a
+faster local/dev build.
 
 ```ts
 {
@@ -207,12 +247,18 @@ Run a single document query for every document retrieved.
   collectionTypes: [
     {
       slug: 'posts',
-      repopulate: false,
+      // Fetch only the first ~50 documents, instead of the whole collection.
+      maxDocs: 50,
     },
   ]
   // ...
 }
 ```
+
+If the number of requests needed for a collection/locale combination looks
+unexpectedly large (more than 20 pages), the plugin logs a warning via the
+Gatsby `reporter` before firing any of those requests, rather than only being
+discoverable after the fact.
 
 ### `repopulate`
 

--- a/plugin/src/__tests__/axios-instance.ts
+++ b/plugin/src/__tests__/axios-instance.ts
@@ -1,5 +1,6 @@
 import axiosRetry from "axios-retry"
 import { createAxiosInstance } from "../axios-instance"
+import { DEFAULT_MAX_PARALLEL_REQUESTS } from "../constants"
 
 jest.mock(`axios-retry`, () => {
   const mockAxiosRetry = jest.fn()
@@ -71,6 +72,25 @@ describe(`createAxiosInstance`, () => {
       await jest.advanceTimersByTimeAsync(50)
 
       expect(resolved).toHaveBeenCalledWith(config)
+    })
+
+    it(`defaults maxParallelRequests to a bounded value rather than unlimited`, async () => {
+      const instance = createAxiosInstance({})
+      const requestInterceptor = (instance.interceptors.request as any).handlers[0].fulfilled
+
+      const resolvedCount = { current: 0 }
+      // Intentionally not awaited as a whole - the request beyond the default
+      // limit never resolves in this test, since nothing frees its slot.
+      Array.from({ length: DEFAULT_MAX_PARALLEL_REQUESTS + 1 }, (_, index) =>
+        requestInterceptor({ url: `/${index}` }).then(() => {
+          resolvedCount.current += 1
+        })
+      )
+
+      await jest.advanceTimersByTimeAsync(50)
+
+      // Exactly the default number of slots are available; one request must still be queued.
+      expect(resolvedCount.current).toEqual(DEFAULT_MAX_PARALLEL_REQUESTS)
     })
 
     it(`queues requests beyond the parallel limit until a slot frees up`, async () => {

--- a/plugin/src/__tests__/fetch.ts
+++ b/plugin/src/__tests__/fetch.ts
@@ -5,6 +5,7 @@ const buildContext = (pluginOptions: { [key: string]: unknown } = {}) => ({
   reporter: {
     info: jest.fn(),
     panic: jest.fn(),
+    warn: jest.fn(),
   },
   pluginOptions,
 })
@@ -220,5 +221,145 @@ describe(`fetchEntities`, () => {
     // Doc "a" fails and is dropped; doc "b" still comes through fully repopulated.
     expect(context.reporter.panic).toHaveBeenCalledTimes(1)
     expect(result.map((entity: any) => entity.title)).toEqual([`Full b`])
+  })
+
+  describe(`maxDocs`, () => {
+    it(`stops paginating once enough documents have been fetched (no locales)`, async () => {
+      const context = buildContext()
+      const pages = {
+        1: { docs: [{ id: 1 }, { id: 2 }], page: 1, totalPages: 50 },
+        2: { docs: [{ id: 3 }, { id: 4 }] },
+        3: { docs: [{ id: 5 }, { id: 6 }] },
+      }
+      context.axiosInstance.mockImplementation(async ({ params }) => ({ data: pages[params?.page ?? 1] }))
+
+      const result = await fetchEntities(
+        { endpoint: `http://localhost/api/posts`, type: `Post`, maxDocs: 5 },
+        context
+      )
+
+      // Page size is 2; reaching 5 docs needs pages 1-3, not all 50.
+      expect(context.axiosInstance).toHaveBeenCalledTimes(3)
+      expect(result.map((entity: any) => entity.id)).toEqual([1, 2, 3, 4, 5])
+    })
+
+    it(`does not fetch any extra pages when the first page already meets maxDocs`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockResolvedValueOnce({
+        data: { docs: [{ id: 1 }, { id: 2 }, { id: 3 }], page: 1, totalPages: 50 },
+      })
+
+      const result = await fetchEntities(
+        { endpoint: `http://localhost/api/posts`, type: `Post`, maxDocs: 2 },
+        context
+      )
+
+      expect(context.axiosInstance).toHaveBeenCalledTimes(1)
+      expect(result.map((entity: any) => entity.id)).toEqual([1, 2])
+    })
+
+    it(`caps documents per locale, not across all locales combined`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockImplementation(async ({ params }) => {
+        if (!params.locale) return { data: { docs: [], page: 1, totalPages: 1 } }
+        return { data: { docs: [{ id: `${params.locale}-1` }, { id: `${params.locale}-2` }] } }
+      })
+
+      const result = await fetchEntities(
+        { endpoint: `http://localhost/api/posts`, type: `Post`, locales: [`en`, `fr`], maxDocs: 1 },
+        context
+      )
+
+      expect(result.map((entity: any) => entity.id)).toEqual([`en-1`, `fr-1`])
+    })
+
+    it(`only repopulates the capped subset of documents, saving requests`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockImplementation(async ({ url, params }) => {
+        if (!params.locale) return { data: { docs: [], page: 1, totalPages: 1 } }
+        if (/\/(a|b|c)$/.test(url)) return { data: { id: url.split(`/`).pop() } }
+        return { data: { docs: [{ id: `a` }, { id: `b` }, { id: `c` }] } }
+      })
+
+      await fetchEntities(
+        {
+          endpoint: `http://localhost/api/posts`,
+          type: `Post`,
+          locales: [`en`],
+          maxDocs: 1,
+          repopulate: true,
+        },
+        context
+      )
+
+      const repopulateCalls = context.axiosInstance.mock.calls.filter(([opts]) => /\/(a|b|c)$/.test(opts.url))
+      expect(repopulateCalls).toHaveLength(1)
+    })
+  })
+
+  describe(`warnings`, () => {
+    it(`warns when "limit" is set inside "params" instead of the dedicated option`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockResolvedValue({ data: { docs: [{ id: 1 }], page: 1, totalPages: 1 } })
+
+      await fetchEntities(
+        { endpoint: `http://localhost/api/posts`, type: `Post`, params: { limit: 1 } },
+        context
+      )
+
+      expect(context.reporter.warn).toHaveBeenCalledWith(expect.stringContaining(`"limit" was set inside "params"`))
+    })
+
+    it(`does not warn about "params.limit" when the dedicated "limit" option is used`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockResolvedValue({ data: { docs: [{ id: 1 }], page: 1, totalPages: 1 } })
+
+      await fetchEntities({ endpoint: `http://localhost/api/posts`, type: `Post`, limit: 1 }, context)
+
+      expect(context.reporter.warn).not.toHaveBeenCalled()
+    })
+
+    it(`warns before fetching when the number of pages exceeds the safety threshold`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockImplementation(async ({ params }) => ({
+        data: { docs: [{ id: params?.page ?? 1 }], page: params?.page ?? 1, totalPages: 50 },
+      }))
+
+      await fetchEntities({ endpoint: `http://localhost/api/posts`, type: `Post` }, context)
+
+      expect(context.reporter.warn).toHaveBeenCalledWith(expect.stringContaining(`About to fetch 49 page(s)`))
+      // The warning must fire before requests go out, not just be true in hindsight.
+      const warnCallOrder = context.reporter.warn.mock.invocationCallOrder[0]
+      const firstPageTwoCallOrder = context.axiosInstance.mock.invocationCallOrder[1]
+      expect(warnCallOrder).toBeLessThan(firstPageTwoCallOrder)
+    })
+
+    it(`does not warn when the number of pages is under the safety threshold`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockImplementation(async ({ params }) => ({
+        data: { docs: [{ id: params?.page ?? 1 }], page: params?.page ?? 1, totalPages: 5 },
+      }))
+
+      await fetchEntities({ endpoint: `http://localhost/api/posts`, type: `Post` }, context)
+
+      expect(context.reporter.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe(`progress logging`, () => {
+    it(`logs a progress summary every 10 pages, distinct from the per-request debug line`, async () => {
+      const context = buildContext()
+      context.axiosInstance.mockImplementation(async ({ params }) => ({
+        data: { docs: [{ id: params?.page ?? 1 }], page: params?.page ?? 1, totalPages: 25 },
+      }))
+
+      await fetchEntities({ endpoint: `http://localhost/api/posts`, type: `Post` }, context)
+
+      const progressLogs = context.reporter.info.mock.calls.filter(([message]) => message.includes(`fetched`))
+      expect(progressLogs).toEqual([
+        [expect.stringContaining(`fetched 10/24 page(s)`)],
+        [expect.stringContaining(`fetched 20/24 page(s)`)],
+      ])
+    })
   })
 })

--- a/plugin/src/axios-instance.ts
+++ b/plugin/src/axios-instance.ts
@@ -1,5 +1,6 @@
 import axios from "axios"
 import axiosRetry from "axios-retry"
+import { DEFAULT_MAX_PARALLEL_REQUESTS } from "./constants"
 
 /**
  * Inspiration from:
@@ -36,7 +37,15 @@ const throttlingInterceptors = (axiosInstance, maxParallelRequests) => {
 }
 
 export const createAxiosInstance = (pluginConfig) => {
-  const { maxParallelRequests = Number.POSITIVE_INFINITY, accessToken, accessCollectionSlug, apiURL } = pluginConfig
+  const {
+    // Unbounded concurrency on a large fetch can overwhelm the origin API or the
+    // build machine. Raising this (or a smaller `limit`/larger page size) trades
+    // memory/API load for wall-clock time — see the README for the tradeoff.
+    maxParallelRequests = DEFAULT_MAX_PARALLEL_REQUESTS,
+    accessToken,
+    accessCollectionSlug,
+    apiURL,
+  } = pluginConfig
 
   const headers: { [key: string]: string } = {}
 

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -9,6 +9,25 @@ export const CACHE_KEYS = {
 } as const
 
 /**
+ * Requests-per-page defaults are driven by the Payload REST API's own `limit`
+ * query param. If a caller sets a very small page size (via `limit`, or by
+ * accident via a raw `params.limit`) on a large collection, pagination will
+ * otherwise silently fire one request per remaining page.
+ */
+export const PAGE_COUNT_WARNING_THRESHOLD = 20
+
+/** How often (in fetched pages) to log a progress summary for a single collection/locale fetch. */
+export const PROGRESS_LOG_INTERVAL = 10
+
+/**
+ * Default cap on requests in flight at once (see axios-instance.ts). Unbounded
+ * concurrency on a large, unpaginated fetch can overwhelm the origin API or the
+ * machine running the build; this keeps a reasonable default while still being
+ * overridable via the `maxParallelRequests` plugin option.
+ */
+export const DEFAULT_MAX_PARALLEL_REQUESTS = 10
+
+/**
  * The IDs for your errors can be arbitrary (since they are scoped to your plugin), but it's good practice to have a system for them.
  * For example, you could start all third-party API errors with 1000x, all transformation errors with 2000x, etc.
  */

--- a/plugin/src/fetch.ts
+++ b/plugin/src/fetch.ts
@@ -10,6 +10,7 @@ import qs from "qs"
 import { flattenDeep, isEmpty, isNumber, isObject, isString } from "lodash"
 import { formatEntity } from "./format-entity"
 import { fetchDataMessage } from "./utils"
+import { PAGE_COUNT_WARNING_THRESHOLD, PROGRESS_LOG_INTERVAL } from "./constants"
 
 import { type LocaleObject, type LocaleString } from "./types"
 
@@ -20,9 +21,96 @@ export type CollectionOptions = {
   /** If locales are set, return an array of entities each with an additional `locale` key. */
   locales?: Array<LocaleString> | Array<LocaleObject>
   params?: { [key: string]: unknown }
+  /**
+   * Sets the Payload REST API's own `limit` query param, i.e. documents requested
+   * PER PAGE - not a cap on total documents returned. Also disables automatic
+   * pagination. Use `maxDocs` to actually cap the total number of documents fetched.
+   */
   limit?: number
+  /** Stop paginating once at least this many documents have been fetched (per locale, if set). */
+  maxDocs?: number
   imageSize?: string
   repopulate?: boolean
+}
+
+/**
+ * `limit` is easy to confuse with the identically-named Payload REST API query
+ * param: setting it inside `params` (rather than as the dedicated `query.limit`)
+ * skips the pagination-disabling behavior entirely, so a small page size there
+ * multiplies the number of pages - and requests - needed to fetch the whole
+ * collection. This is exactly the kind of config mistake that silently turns a
+ * handful of requests into thousands; warn about it immediately.
+ */
+const warnIfLimitSetViaRawParams = (
+  reporter: { warn: (message: string) => void },
+  params: { [key: string]: unknown },
+  query: CollectionOptions
+): void => {
+  if (isNumber(params?.limit) && !isNumber(query.limit)) {
+    reporter.warn(
+      `[gatsby-source-payload-cms] "limit" was set inside "params" for ${query.endpoint} - this is sent ` +
+        `as a raw query parameter and does NOT enable this plugin's pagination controls, so a small value ` +
+        `here can multiply the number of requests needed to fetch the whole collection. Use the dedicated ` +
+        `"limit" option to set page size, or "maxDocs" to cap the total number of documents fetched.`
+    )
+  }
+}
+
+/**
+ * Warn before firing a surprisingly large number of page requests for a single
+ * collection/locale combination, rather than letting it run silently.
+ */
+const warnIfTooManyPages = (
+  reporter: { warn: (message: string) => void },
+  { pagesToGet, localeCount, endpoint }: { pagesToGet: Array<number>; localeCount: number; endpoint: string }
+): void => {
+  if (pagesToGet.length <= PAGE_COUNT_WARNING_THRESHOLD) {
+    return
+  }
+  const totalRequests = pagesToGet.length * Math.max(localeCount, 1)
+  reporter.warn(
+    `[gatsby-source-payload-cms] About to fetch ${pagesToGet.length} page(s) ${
+      localeCount > 1 ? `x ${localeCount} locale(s) (~${totalRequests} requests) ` : ``
+    }from ${endpoint}. If this is unexpected, check the collection's "limit" (page size) and consider ` +
+      `setting "maxDocs" to cap the total number of documents fetched.`
+  )
+}
+
+/**
+ * Reduce `pagesToGet` down to only the pages needed to reach `maxDocs`, using
+ * `pageSize` (the size of a page already fetched, or about to be) as an estimate
+ * of how many documents each additional page will contain. `alreadyFetched` is
+ * the number of documents already counted towards `maxDocs` that are NOT part of
+ * `pagesToGet` itself (e.g. the initial unpaginated response for a collection
+ * without locales - for locales, page 1 is always in `pagesToGet` already, so
+ * pass 0).
+ */
+const capPagesToGetForMaxDocs = (
+  pagesToGet: Array<number>,
+  maxDocs: number | undefined,
+  pageSize: number,
+  alreadyFetched: number
+): Array<number> => {
+  if (!isNumber(maxDocs)) {
+    return pagesToGet
+  }
+  const safePageSize = pageSize || 1
+  const remaining = Math.max(0, maxDocs - alreadyFetched)
+  const pagesNeeded = Math.ceil(remaining / safePageSize)
+  return pagesToGet.slice(0, pagesNeeded)
+}
+
+/** Log a concise progress summary every `PROGRESS_LOG_INTERVAL` pages, distinct from the per-request debug line. */
+const logProgress = (
+  reporter: { info: (message: string) => void },
+  counter: { fetched: number },
+  total: number,
+  label: string
+): void => {
+  counter.fetched += 1
+  if (counter.fetched % PROGRESS_LOG_INTERVAL === 0 && counter.fetched < total) {
+    reporter.info(`[gatsby-source-payload-cms] ${label}: fetched ${counter.fetched}/${total} page(s)...`)
+  }
 }
 
 export const fetchEntity = async (query: CollectionOptions, context) => {
@@ -112,6 +200,8 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
 
   const params = query.params || {}
 
+  warnIfLimitSetViaRawParams(reporter, params, query)
+
   const skipPagination = isNumber(query.limit)
 
   const repopulate = query.repopulate || false
@@ -164,10 +254,20 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
       }
     }
 
+    // `data.length` (the size of the page already fetched above) is used as an
+    // estimate of how many documents each further page will contain.
+    const pageSize = Array.isArray(data) ? data.length : 0
+    pagesToGet = capPagesToGetForMaxDocs(pagesToGet, query.maxDocs, pageSize, locales.length > 0 ? 0 : data.length)
+
+    warnIfTooManyPages(reporter, { pagesToGet, localeCount: locales.length, endpoint: query.endpoint })
+
+    const totalPagesToFetch = pagesToGet.length
+
     const fallbackLocale = context.pluginOptions?.fallbackLocale
     if (locales.length > 0) {
       const localizationsPromises = locales.map(async (locale) => {
         const localeString = isString(locale) ? locale : locale.locale
+        const pagesFetchedCounter = { fetched: 0 }
         const fetchPagesPromises = pagesToGet.map((page) => {
           return (async () => {
             const fetchOptions = {
@@ -180,11 +280,12 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
                 ...(isObject(locale) && (locale as LocaleObject).params)
               },
             }
-            
+
             reporter.info(fetchDataMessage(fetchOptions.url, options.paramsSerializer.serialize(fetchOptions.params)))
 
             try {
               const data = await axiosInstance(fetchOptions)
+              logProgress(reporter, pagesFetchedCounter, totalPagesToFetch, `${query.type} (${localeString})`)
               return data.data.docs
             } catch (error) {
               reporter.panic(`Failed to fetch data from Payload ${fetchOptions.url}`, error)
@@ -192,10 +293,12 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
           })()
         })
         const results = await Promise.all(fetchPagesPromises)
+        const cappedResults = isNumber(query.maxDocs)
+          ? flattenDeep(results).filter(Boolean).slice(0, query.maxDocs)
+          : flattenDeep(results).filter(Boolean)
 
         if (!repopulate) {
-          return flattenDeep(results)
-          .filter(Boolean)
+          return cappedResults
           .map((entry) =>
             formatEntity(
               {
@@ -220,8 +323,8 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
             ...(isObject(locale) && (locale as LocaleObject).params)
           },
         }
-        
-        const articlePromises = flattenDeep(results).map((doc) => {
+
+        const articlePromises = cappedResults.map((doc) => {
           return (async () => {
             const options = {
               ...fetchOptions,
@@ -259,6 +362,7 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
 
       return flattenDeep(localizationsData)
     } else {
+      const pagesFetchedCounter = { fetched: 0 }
       const fetchPagesPromises = pagesToGet.map((page) => {
         return (async () => {
           const fetchOptions = {
@@ -273,6 +377,7 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
 
           try {
             const data = await axiosInstance(fetchOptions)
+            logProgress(reporter, pagesFetchedCounter, totalPagesToFetch, query.type)
             return data.data.docs
           } catch (error) {
             reporter.panic(`Failed to fetch data from Payload ${fetchOptions.url}`, error)
@@ -282,7 +387,8 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
 
       const results = await Promise.all(fetchPagesPromises)
 
-      const cleanedData = [...data, ...flattenDeep(results).filter(Boolean)]
+      const combinedData = [...data, ...flattenDeep(results).filter(Boolean)]
+      const cleanedData = (isNumber(query.maxDocs) ? combinedData.slice(0, query.maxDocs) : combinedData)
         .map((entry) =>
           formatEntity(
             {

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -29,8 +29,16 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
             })),
           ),
           params: Joi.object(),
-          /** Override limit in query params and disable paginated query */
+          /**
+           * Sets the Payload REST API's own `limit` query param, i.e. the number of
+           * documents requested PER PAGE - not a cap on the total number of documents
+           * returned. Also disables this plugin's automatic pagination, so only the
+           * first page (of this size) is fetched. To cap total documents fetched, use
+           * `maxDocs` instead.
+           */
           limit: Joi.number(),
+          /** Stop paginating once at least this many documents have been fetched. Unlike `limit`, does not change the API page size. */
+          maxDocs: Joi.number(),
           /** Repopulate results with a query on each result. Use with caution - can significantly increase the number of API calls. Included to get around an issue where the depth parameter is not always respected on paginated queries. */
           /* Currently only supported for queries with locales */
           repopulate: Joi.boolean(),
@@ -56,7 +64,7 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
             })),
           ),
           params: Joi.object(),
-          /** Override limit in query params and disable paginated query */
+          /** Sets the Payload REST API's own `limit` query param. Globals are singleton documents, so this rarely matters. */
           limit: Joi.number(),
           /** Defaults to `globals/:slug` */
           apiPath: Joi.string(),
@@ -81,8 +89,16 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
             })),
           ),
           params: Joi.object(),
-          /** Override limit in query params and disable paginated query */
+          /**
+           * Sets the Payload REST API's own `limit` query param, i.e. the number of
+           * documents requested PER PAGE - not a cap on the total number of documents
+           * returned. Also disables this plugin's automatic pagination, so only the
+           * first page (of this size) is fetched. To cap total documents fetched, use
+           * `maxDocs` instead.
+           */
           limit: Joi.number(),
+          /** Stop paginating once at least this many documents have been fetched. Unlike `limit`, does not change the API page size. */
+          maxDocs: Joi.number(),
           /** Optional. Retrieve an image size. If blank, the original URL will be returned. */
           imageSize: Joi.string(),
         })
@@ -92,7 +108,12 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     accessToken: Joi.string(),
     // Optional. Collection slug where API key access available. Use if your API is protected. If blank, this is set to `users`.
     accessCollectionSlug: Joi.string(),
-    // Optional. Throttle parallel requests.
+    /**
+     * Optional. Caps requests in flight at once. Defaults to a moderate value
+     * (see DEFAULT_MAX_PARALLEL_REQUESTS in constants.ts) rather than unbounded.
+     * Lowering this trades wall-clock time for lower API/machine load; raising
+     * it (or raising a collection's page size via `limit`) does the opposite.
+     */
     maxParallelRequests: Joi.number(),
     // Optional. Retry requests using https://www.npmjs.com/package/axios-retry.
     retries: Joi.number(),

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -31,7 +31,24 @@ export interface ICollectionTypeObject {
   slug: string
   locales?: Array<LocaleString> | Array<LocaleObject>
   params?: { [key: string]: string }
+  /**
+   * Sets the Payload REST API's own `limit` query param — i.e. how many documents
+   * are requested **per page**, not a cap on the total number of documents
+   * returned. Setting this also disables this plugin's automatic pagination, so
+   * only the first page (of this size) is fetched.
+   *
+   * To actually cap the total number of documents fetched for a collection
+   * (e.g. for a fast local/dev build), use `maxDocs` instead.
+   */
   limit?: number
+  /**
+   * Stop paginating once at least this many documents have been fetched for the
+   * collection (per locale, if locales are set). Unlike `limit`, this does not
+   * change the API page size — it just stops requesting further pages once
+   * enough documents have come back, so it's a genuine "give me N documents"
+   * cap rather than a page-size override.
+   */
+  maxDocs?: number
   repopulate?: boolean
   apiPath?: string
 }
@@ -40,7 +57,6 @@ export interface IUploadTypeObject extends ICollectionTypeObject {
   slug: string
   locales?: Array<string>
   params?: { [key: string]: string }
-  limit?: number
   imageSize?: string
 }
 
@@ -48,7 +64,6 @@ export interface IGlobalTypeObject extends ICollectionTypeObject {
   slug: string
   locales?: Array<LocaleString> | Array<LocaleObject>
   params?: { [key: string]: string }
-  limit?: number
   apiPath?: string
 }
 


### PR DESCRIPTION
## Summary

A real-world incident: setting `limit=1` on a ~3,500-document collection turned 13 requests into 3,480 (one per document), causing an 11-minute sourcing step and a CI timeout, with no warning or log output that made it obvious.

**Root cause**: the dedicated `limit` option already disables pagination when set (it fetches exactly one page of that size) - it can't explode on its own. The explosion happens when `limit` is set inside the raw `params` passthrough instead, which collides with Payload's own REST API query parameter of the same name and bypasses this plugin's pagination controls entirely.

## Changes

- **Clarify `limit`**: JSDoc (`fetch.ts`, `types.ts`), Joi schema comments, and a new README callout all state plainly that `limit` sets page size, not a cap on total results.
- **Add `maxDocs`**: genuinely stops pagination once enough documents are fetched, for both localized and non-localized paths - including capping `repopulate` calls (saves requests, not just truncates output).
- **Warn before firing requests**: via the Gatsby `reporter`, when a collection/locale's computed page count exceeds a sane threshold (20), and specifically when `limit` is set via raw `params` instead of the dedicated option (the actual footgun above).
- **Bound concurrency by default**: `maxParallelRequests` now defaults to `10` instead of unbounded, via a new `DEFAULT_MAX_PARALLEL_REQUESTS` constant. Documents the concurrency/page-size tradeoff in a new README "Performance" section (previously undocumented at all).
- **Progress logging**: every 10 pages, distinct from the existing per-request debug line, so a long-running sourcing step is diagnosable without reading plugin source.
- Also fixes a duplicated "Repopulate" section in the README noticed along the way.

## Tests

11 new tests: `maxDocs` capping and repopulate-savings on both the localized and non-localized branches, both warnings (including asserting the page-count warning's `invocationCallOrder` precedes the actual request), progress logging, and the new `maxParallelRequests` default.

## Test plan

- [x] `yarn test` - 88 tests pass
- [x] `tsc --noEmit` - clean build
- [ ] CI passes on this PR