### PR TITLE
fix(plugin): revert maxParallelRequests default to unbounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Simple config:
 | `collectionTypes` | `['posts']` | Specifiy collections to retrive along with any collection-specific options. [More](#collection-types). |
 | `globalTypes` | `['nav']` | Specifiy globals to retrive along with any global-specific options. [More](#global-types). |
 | `nodeTransform` | `{ ['myField'] => (myField) => transformMyField(myField) }` | Incorporate functions to transform the value returned for a given Payload field. [More](#node-transform) |
-| `maxParallelRequests` | `10` | Cap requests in flight at once. Defaults to `10`. [More](#performance-maxparallelrequests-and-limit). |
+| `maxParallelRequests` | `10` | Cap requests in flight at once. Unbounded by default. [More](#performance-maxparallelrequests-and-limit). |
 | `retries` | `3` | Retry failed requests using [axios-retry](https://www.npmjs.com/package/axios-retry). |
 
 ### Example
@@ -86,20 +86,30 @@ Simple config:
 
 ### Performance: `maxParallelRequests` and `limit`
 
-`maxParallelRequests` caps how many requests are in flight at once (default:
-`10`). This trades wall-clock sourcing time against load on the origin API and
-the machine running the build:
+`maxParallelRequests` caps how many requests are in flight at once. **It is
+unbounded by default** - existing configs that never set it keep exactly the
+concurrency they always had. This is an opt-in knob, not something you need
+to set to avoid a regression:
 
-- Raising `maxParallelRequests` fetches more pages concurrently, finishing
-  faster but increasing load on the Payload API and memory use during the
-  build.
-- Lowering it reduces that load, at the cost of a longer sourcing step.
+- Setting `maxParallelRequests` reduces load on the Payload API and memory
+  use during the build, at the cost of a longer sourcing step - useful if
+  you're seeing origin API errors or high memory usage during sourcing on a
+  wide/large fetch.
 - A collection's page size (`limit`) interacts with this: a smaller page size
-  means more total pages/requests for the same collection, so lowering
-  `limit` while also lowering `maxParallelRequests` compounds into a much
-  longer build — the plugin logs a warning if a collection's page count looks
+  means more total pages/requests for the same collection, so combining a
+  small `limit` with a low `maxParallelRequests` compounds into a much
+  longer build. The plugin logs a warning if a collection's page count looks
   unexpectedly large, and periodic progress (every 10 pages) while fetching,
   so a slow sourcing step is diagnosable without reading the plugin's source.
+
+> **Note on 1.1.2**: that release briefly defaulted `maxParallelRequests` to
+> `10` instead of unbounded, which could turn a wide sourcing job (many
+> collections x locales) that previously finished comfortably into one that
+> times out, with no config change on the consumer's end. This was a
+> behavioral change that should never have shipped in a patch release, and
+> was reverted in 1.1.3. If you're on 1.1.2, upgrade to 1.1.3 or later, or set
+> `maxParallelRequests` explicitly to restore your desired concurrency in the
+> meantime.
 
 ### Collection Types
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [1.1.2](https://github.com/thompsonsj/gatbsy-source-payload-cms/compare/v1.1.1...v1.1.2) (2026-08-12)
 
+> **⚠️ Known issue, fixed in 1.1.3**: this release unintentionally changed
+> `maxParallelRequests`'s default from unbounded to `10`. For a sourcing job
+> wide enough (many collections/locales fetched concurrently), this can turn
+> a build that previously completed comfortably into one that times out, with
+> no config change required to trigger it. If you're on 1.1.2, upgrade to
+> 1.1.3 or later, or set `maxParallelRequests` explicitly in the meantime.
 
 ### Bug Fixes
 

--- a/plugin/src/__tests__/axios-instance.ts
+++ b/plugin/src/__tests__/axios-instance.ts
@@ -1,6 +1,5 @@
 import axiosRetry from "axios-retry"
 import { createAxiosInstance } from "../axios-instance"
-import { DEFAULT_MAX_PARALLEL_REQUESTS } from "../constants"
 
 jest.mock(`axios-retry`, () => {
   const mockAxiosRetry = jest.fn()
@@ -74,23 +73,30 @@ describe(`createAxiosInstance`, () => {
       expect(resolved).toHaveBeenCalledWith(config)
     })
 
-    it(`defaults maxParallelRequests to a bounded value rather than unlimited`, async () => {
+    it(`defaults maxParallelRequests to unbounded, matching pre-1.1.2 behavior`, async () => {
+      // Regression test for a bug shipped in 1.1.2: defaulting this to a bounded
+      // value (10) turned a wide sourcing job (many collections x locales,
+      // ~300+ concurrent page-1 requests in one real-world report) that
+      // previously completed in one throttling "tick" into one that serialized
+      // into dozens of sequential batches, with no config change on the
+      // consumer's end. Reverted in 1.1.3 - this asserts the default stays
+      // unbounded so that regression can't silently reappear.
       const instance = createAxiosInstance({})
       const requestInterceptor = (instance.interceptors.request as any).handlers[0].fulfilled
 
+      const REQUEST_COUNT = 300
       const resolvedCount = { current: 0 }
-      // Intentionally not awaited as a whole - the request beyond the default
-      // limit never resolves in this test, since nothing frees its slot.
-      Array.from({ length: DEFAULT_MAX_PARALLEL_REQUESTS + 1 }, (_, index) =>
+      Array.from({ length: REQUEST_COUNT }, (_, index) =>
         requestInterceptor({ url: `/${index}` }).then(() => {
           resolvedCount.current += 1
         })
       )
 
+      // A single throttling interval tick is enough to resolve every request
+      // when concurrency is unbounded - none of them should still be queued.
       await jest.advanceTimersByTimeAsync(50)
 
-      // Exactly the default number of slots are available; one request must still be queued.
-      expect(resolvedCount.current).toEqual(DEFAULT_MAX_PARALLEL_REQUESTS)
+      expect(resolvedCount.current).toEqual(REQUEST_COUNT)
     })
 
     it(`queues requests beyond the parallel limit until a slot frees up`, async () => {

--- a/plugin/src/axios-instance.ts
+++ b/plugin/src/axios-instance.ts
@@ -1,6 +1,5 @@
 import axios from "axios"
 import axiosRetry from "axios-retry"
-import { DEFAULT_MAX_PARALLEL_REQUESTS } from "./constants"
 
 /**
  * Inspiration from:
@@ -38,10 +37,12 @@ const throttlingInterceptors = (axiosInstance, maxParallelRequests) => {
 
 export const createAxiosInstance = (pluginConfig) => {
   const {
-    // Unbounded concurrency on a large fetch can overwhelm the origin API or the
-    // build machine. Raising this (or a smaller `limit`/larger page size) trades
-    // memory/API load for wall-clock time — see the README for the tradeoff.
-    maxParallelRequests = DEFAULT_MAX_PARALLEL_REQUESTS,
+    // Unbounded by default, matching pre-1.1.2 behavior - this is an opt-in knob,
+    // not something existing consumers should have to set to avoid a regression.
+    // Setting it can help large/wide sourcing operations avoid overwhelming the
+    // origin API or the build machine, at the cost of wall-clock time — see the
+    // README for the tradeoff.
+    maxParallelRequests = Number.POSITIVE_INFINITY,
     accessToken,
     accessCollectionSlug,
     apiURL,

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -20,14 +20,6 @@ export const PAGE_COUNT_WARNING_THRESHOLD = 20
 export const PROGRESS_LOG_INTERVAL = 10
 
 /**
- * Default cap on requests in flight at once (see axios-instance.ts). Unbounded
- * concurrency on a large, unpaginated fetch can overwhelm the origin API or the
- * machine running the build; this keeps a reasonable default while still being
- * overridable via the `maxParallelRequests` plugin option.
- */
-export const DEFAULT_MAX_PARALLEL_REQUESTS = 10
-
-/**
  * The IDs for your errors can be arbitrary (since they are scoped to your plugin), but it's good practice to have a system for them.
  * For example, you could start all third-party API errors with 1000x, all transformation errors with 2000x, etc.
  */

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -109,10 +109,11 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     // Optional. Collection slug where API key access available. Use if your API is protected. If blank, this is set to `users`.
     accessCollectionSlug: Joi.string(),
     /**
-     * Optional. Caps requests in flight at once. Defaults to a moderate value
-     * (see DEFAULT_MAX_PARALLEL_REQUESTS in constants.ts) rather than unbounded.
-     * Lowering this trades wall-clock time for lower API/machine load; raising
-     * it (or raising a collection's page size via `limit`) does the opposite.
+     * Optional. Caps requests in flight at once. Unbounded by default (opt-in
+     * only - existing consumers should never see a behavior change from this
+     * being unset). Lowering this trades wall-clock time for lower API/machine
+     * load; raising a collection's page size via `limit` has a similar effect
+     * in the other direction.
      */
     maxParallelRequests: Joi.number(),
     // Optional. Retry requests using https://www.npmjs.com/package/axios-retry.


### PR DESCRIPTION
## Summary

1.1.2 (#108) shipped a real regression: it changed `createAxiosInstance`'s default `maxParallelRequests` from `Number.POSITIVE_INFINITY` to a new bounded constant (`10`), bundled in alongside several genuinely-additive fixes (`maxDocs`, a `params.limit` collision warning, progress logging) as if it were equally non-breaking. It wasn't — it's a behavioral change for every existing consumer who left `maxParallelRequests` unset, which is presumably most of them, since it was never a documented, actively-chosen option before.

**Reported real-world impact**: a consumer upgraded 1.1.1 -> 1.1.2 with no other change, to pick up `maxDocs`. Their build sources ~25 collections x 12 locales (~300 concurrent page-1 requests). Under the old unbounded default this completed sourcing in ~895s; under the new default of 10 it serialized into ~30 sequential batches and didn't finish within their CI build timeout — a regression from "succeeds comfortably" to "always times out," triggered purely by a dependency bump.

This is a semver violation as shipped: a default behavior change that can turn a passing build into a failing one should never ship in a patch version.

## Fix

Reverts the default to unbounded, matching pre-1.1.2 behavior. `maxParallelRequests` remains available as an opt-in knob for consumers who want to trade wall-clock time for lower API/machine load.

**Audited the rest of the 1.1.2 diff** for other default-behavior changes, per the report's ask: `maxDocs` is a no-op when unset (confirmed in `capPagesToGetForMaxDocs`), and both new warnings plus progress logging only ever call `reporter.warn`/`reporter.info` — no control-flow or output change. `maxParallelRequests` was the only actual behavioral change; everything else in 1.1.2 was genuinely additive.

## Tests

Added a regression test asserting the default stays unbounded under a wide concurrent workload (300 simultaneous requests all resolving within one throttling tick, modeled on the reported real-world request count). Verified by hand that this test fails against the 1.1.2 behavior and passes against this fix.

Also added a note to the 1.1.2 CHANGELOG entry and a README callout, since currently nothing visible to a consumer flags this risk before/while upgrading to 1.1.2.

## Follow-up needed outside this PR

There's no automated npm publish in this repo (confirmed: only `node.js.yml` and `release-please.yml` exist, neither runs `npm publish`). Once this merges and release-please's PR is merged/tagged as 1.1.3, someone with npm publish access needs to:
- `npm publish` from `plugin/` to actually ship 1.1.3
- Consider `npm deprecate gatsby-source-payload-cms@1.1.2 "..."` pointing at 1.1.3, so anyone installing without a lockfile doesn't land on the broken version

## Test plan

- [x] `yarn test` — 88 tests pass
- [x] `tsc --noEmit` — clean build
- [x] Manually confirmed the new regression test fails against the reverted (1.1.2) behavior and passes against this fix
- [ ] CI passes on this PR