### PR TITLE
fix(plugin): fix five resilience bugs found via TDD

### DIFF
--- a/plugin/src/__tests__/axios-instance.ts
+++ b/plugin/src/__tests__/axios-instance.ts
@@ -73,6 +73,21 @@ describe(`createAxiosInstance`, () => {
       expect(resolved).toHaveBeenCalledWith(config)
     })
 
+    it.each([0, -1, -100])(
+      `does not deadlock when maxParallelRequests is %i (Joi rejects this, but the runtime shouldn't hang either)`,
+      async (invalidValue) => {
+        const instance = createAxiosInstance({ maxParallelRequests: invalidValue })
+        const requestInterceptor = (instance.interceptors.request as any).handlers[0].fulfilled
+
+        const resolved = jest.fn()
+        requestInterceptor({ url: `/foo` }).then(resolved)
+
+        await jest.advanceTimersByTimeAsync(50)
+
+        expect(resolved).toHaveBeenCalled()
+      }
+    )
+
     it(`defaults maxParallelRequests to unbounded, matching pre-1.1.2 behavior`, async () => {
       // Regression test for a bug shipped in 1.1.2: defaulting this to a bounded
       // value (10) turned a wide sourcing job (many collections x locales,

--- a/plugin/src/__tests__/fetch.ts
+++ b/plugin/src/__tests__/fetch.ts
@@ -78,6 +78,18 @@ describe(`fetchEntity`, () => {
 
     expect(context.reporter.panic).toHaveBeenCalledTimes(1)
   })
+
+  it(`panics gracefully on network-level errors that have no "response" at all`, async () => {
+    const context = buildContext()
+    // A real axios network error (DNS failure, connection refused, timeout) has
+    // no `.response` - only HTTP error responses do.
+    context.axiosInstance.mockRejectedValueOnce(new Error(`Network Error`))
+
+    const result = await fetchEntity({ endpoint: `http://localhost/api/home`, type: `Home` }, context)
+
+    expect(context.reporter.panic).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([])
+  })
 })
 
 describe(`fetchEntities`, () => {
@@ -94,6 +106,21 @@ describe(`fetchEntities`, () => {
 
     expect(context.axiosInstance).toHaveBeenCalledTimes(3)
     expect(result.map((entity) => entity.id)).toEqual([1, 2, 3])
+  })
+
+  it(`drops null/falsy entries in the first page's own docs, not just later pages`, async () => {
+    const context = buildContext()
+    // A malformed or partially-corrupted API response could contain a null
+    // entry in `docs` (e.g. a dangling/broken relationship expansion). Only
+    // pages fetched *beyond* the first were being defended against this -
+    // the first page's own docs were passed straight through to formatEntity.
+    context.axiosInstance.mockResolvedValueOnce({
+      data: { docs: [{ id: 1 }, null, { id: 2 }], page: 1, totalPages: 1 },
+    })
+
+    const result = await fetchEntities({ endpoint: `http://localhost/api/posts`, type: `Post` }, context)
+
+    expect(result.map((entity: any) => entity.id)).toEqual([1, 2])
   })
 
   it(`does not paginate when a limit is provided`, async () => {

--- a/plugin/src/__tests__/plugin-options-schema.ts
+++ b/plugin/src/__tests__/plugin-options-schema.ts
@@ -71,4 +71,35 @@ describe(`pluginOptionsSchema`, () => {
     expect(isValid).toBe(true)
     expect(errors).toEqual([])
   })
+  it(`rejects a maxParallelRequests of 0, which would deadlock every request`, async () => {
+    const options = {
+      endpoint: `http://localhost:4000/graphql`,
+      maxParallelRequests: 0,
+    }
+
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, options)
+
+    expect(isValid).toBe(false)
+  })
+  it(`rejects a negative maxParallelRequests`, async () => {
+    const options = {
+      endpoint: `http://localhost:4000/graphql`,
+      maxParallelRequests: -1,
+    }
+
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, options)
+
+    expect(isValid).toBe(false)
+  })
+  it(`accepts a positive integer maxParallelRequests`, async () => {
+    const options = {
+      endpoint: `http://localhost:4000/graphql`,
+      maxParallelRequests: 5,
+    }
+
+    const { isValid, errors } = await testPluginOptionsSchema(pluginOptionsSchema, options)
+
+    expect(isValid).toBe(true)
+    expect(errors).toEqual([])
+  })
 })

--- a/plugin/src/__tests__/source-nodes.ts
+++ b/plugin/src/__tests__/source-nodes.ts
@@ -258,6 +258,56 @@ describe(`sourceNodes (main function)`, () => {
     expect((createRemoteFileNode as jest.Mock).mock.calls[0][0].url).toEqual(`/media/a.jpg`);
   });
 
+  it(`awaits createLocalFileNode before resolving, so file nodes are guaranteed to exist when sourcing finishes`, async () => {
+    // createLocalFileNode is async (it downloads a file and creates a node).
+    // If sourceNodes doesn't await it, sourceNodes can resolve before the file
+    // node exists (a race downstream schema/page-building code can lose), and
+    // a rejected download becomes an unhandled promise rejection outside
+    // Gatsby's own error handling instead of a clean, reported build failure.
+    const gatsbyApi = buildGatsbyApi();
+    (fetchEntities as jest.Mock).mockResolvedValueOnce([
+      { id: `1`, gatsbyNodeType: `headshots`, url: `/media/a.jpg` },
+    ]);
+
+    let resolveFileNode: (value: unknown) => void;
+    (createRemoteFileNode as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFileNode = resolve;
+        })
+    );
+
+    let sourceNodesResolved = false;
+    const sourceNodesPromise = callSourceNodes(gatsbyApi, {
+      ...basePluginOptions,
+      uploadTypes: [`headshots`],
+      localFiles: true,
+    }).then(() => {
+      sourceNodesResolved = true;
+    });
+
+    // Flush microtasks until the download has actually started, without ever
+    // resolving it.
+    for (let i = 0; i < 20 && (createRemoteFileNode as jest.Mock).mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(createRemoteFileNode).toHaveBeenCalledTimes(1);
+
+    // Keep flushing well beyond that point. If createLocalFileNode were fired
+    // and forgotten (not awaited), nothing would block sourceNodes from
+    // finishing here, even though resolveFileNode was never called - so this
+    // is the assertion that actually distinguishes "properly awaited" from
+    // "looked awaited by timing coincidence".
+    for (let i = 0; i < 50; i++) {
+      await Promise.resolve();
+    }
+    expect(sourceNodesResolved).toBe(false);
+
+    resolveFileNode({ id: `file-1` });
+    await sourceNodesPromise;
+    expect(sourceNodesResolved).toBe(true);
+  });
+
   it(`creates an asset node and links its id onto the upload node when imageCdn is set`, async () => {
     const gatsbyApi = buildGatsbyApi();
     (fetchEntities as jest.Mock).mockResolvedValueOnce([

--- a/plugin/src/__tests__/utils.ts
+++ b/plugin/src/__tests__/utils.ts
@@ -111,6 +111,16 @@ describe(`fn: normalizeCollections`, () => {
       },
     ])
   })
+  it(`does not drop the endpoint's path when it is missing a trailing slash`, () => {
+    // new URL('posts', 'http://x/api') resolves to 'http://x/posts', silently
+    // dropping "/api" - a missing trailing slash on `endpoint` must not do this.
+    expect(normalizeCollections([`posts`], `http://localhost:8000/api`)).toEqual([
+      {
+        endpoint: `http://localhost:8000/api/posts`,
+        type: `posts`,
+      },
+    ])
+  })
 })
 
 describe(`fn: normalizeGlobals`, () => {
@@ -191,6 +201,14 @@ describe(`fn: normalizeGlobals`, () => {
         endpoint: `http://localhost:8000/api/header/icu`,
         slug: `nav`,
         apiPath: `header/icu`,
+        type: `nav`,
+      },
+    ])
+  })
+  it(`does not drop the endpoint's path when it is missing a trailing slash`, () => {
+    expect(normalizeGlobals([`nav`], `http://localhost:8000/api`)).toEqual([
+      {
+        endpoint: `http://localhost:8000/api/globals/nav`,
         type: `nav`,
       },
     ])

--- a/plugin/src/axios-instance.ts
+++ b/plugin/src/axios-instance.ts
@@ -42,11 +42,20 @@ export const createAxiosInstance = (pluginConfig) => {
     // Setting it can help large/wide sourcing operations avoid overwhelming the
     // origin API or the build machine, at the cost of wall-clock time — see the
     // README for the tradeoff.
-    maxParallelRequests = Number.POSITIVE_INFINITY,
+    maxParallelRequests: configuredMaxParallelRequests = Number.POSITIVE_INFINITY,
     accessToken,
     accessCollectionSlug,
     apiURL,
   } = pluginConfig
+
+  // The plugin options schema already rejects values below 1 - this is a
+  // second line of defense so a bad value can never deadlock every request
+  // waiting for a free slot that can never exist, even if schema validation
+  // is bypassed (e.g. createAxiosInstance called directly).
+  const maxParallelRequests =
+    isFinite(configuredMaxParallelRequests) && configuredMaxParallelRequests >= 1
+      ? configuredMaxParallelRequests
+      : Number.POSITIVE_INFINITY
 
   const headers: { [key: string]: string } = {}
 

--- a/plugin/src/fetch.ts
+++ b/plugin/src/fetch.ts
@@ -188,7 +188,11 @@ export const fetchEntity = async (query: CollectionOptions, context) => {
       ]
     }
   } catch (error) {
-    if (error.response.status !== 404) {
+    // Network-level failures (DNS, connection refused, timeout) have no `.response`
+    // at all - only HTTP error responses do. Guard the optional chain rather than
+    // assuming `.response` exists, so those still panic with a clear message
+    // instead of crashing on `Cannot read properties of undefined`.
+    if (error.response?.status !== 404) {
       reporter.panic(`Failed to fetch data from Payload ${options.url} with ${JSON.stringify(options)}`, error)
     }
     return []
@@ -387,7 +391,7 @@ export const fetchEntities = async (query: CollectionOptions, context) => {
 
       const results = await Promise.all(fetchPagesPromises)
 
-      const combinedData = [...data, ...flattenDeep(results).filter(Boolean)]
+      const combinedData = [...data.filter(Boolean), ...flattenDeep(results).filter(Boolean)]
       const cleanedData = (isNumber(query.maxDocs) ? combinedData.slice(0, query.maxDocs) : combinedData)
         .map((entry) =>
           formatEntity(

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -115,7 +115,9 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
      * load; raising a collection's page size via `limit` has a similar effect
      * in the other direction.
      */
-    maxParallelRequests: Joi.number(),
+    // A value of 0 or below would deadlock the throttling interceptor - every
+    // request would wait forever for a free slot that can never exist.
+    maxParallelRequests: Joi.number().integer().min(1),
     // Optional. Retry requests using https://www.npmjs.com/package/axios-retry.
     retries: Joi.number(),
     fallbackLocale: Joi.string(),

--- a/plugin/src/source-nodes.ts
+++ b/plugin/src/source-nodes.ts
@@ -177,7 +177,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async (gatsbyApi, pluginOp
     for (const upload of result) {
       let imageCdnId
       if (pluginOptions.localFiles) {
-        createLocalFileNode(context, upload, relationshipIds)
+        await createLocalFileNode(context, upload, relationshipIds)
       }
       if (pluginOptions.imageCdn) {
         imageCdnId = await createAssetNode(context, upload, relationshipIds)

--- a/plugin/src/utils.ts
+++ b/plugin/src/utils.ts
@@ -119,12 +119,23 @@ export const payloadImageUrl = (
   return url ? `${removeTrailingSlash(baseUrl)}${url}` : undefined
 }
 
+/**
+ * `new URL(relativePath, base)` treats a base URL's last path segment as a
+ * "file" to be replaced unless the base ends with a slash - e.g.
+ * `new URL('posts', 'https://x/api')` resolves to `https://x/posts`, silently
+ * dropping "/api". A trailing slash on `endpoint` is easy to omit (both forms
+ * are valid, equally plausible URLs), so guarantee one here rather than
+ * relying on every caller to remember it.
+ */
+const ensureTrailingSlash = (url: string): string => (url.endsWith(`/`) ? url : `${url}/`)
+
 export const normalizeGlobals = (globalTypes: Array<string | IGlobalTypeObject> | undefined, endpoint: string) => {
   if (!globalTypes) {
     return []
   }
+  const normalizedEndpoint = ensureTrailingSlash(endpoint)
   return globalTypes.map((globalType) => {
-    return normalizeGlobal(globalType, endpoint)
+    return normalizeGlobal(globalType, normalizedEndpoint)
   })
 }
 
@@ -135,7 +146,8 @@ export const normalizeCollections = (
   if (!collectionTypes) {
     return []
   }
-  return collectionTypes.map((collectionType) => normalizeCollection(collectionType, endpoint))
+  const normalizedEndpoint = ensureTrailingSlash(endpoint)
+  return collectionTypes.map((collectionType) => normalizeCollection(collectionType, normalizedEndpoint))
 }
 
 const normalizeCollection = (collectionType: string | ICollectionTypeObject, endpoint: string) => {


### PR DESCRIPTION
## Summary

A dedicated bug hunt across the plugin, each bug found and fixed via strict TDD (failing test confirmed against current code first, then the fix). Five real issues:

1. **Silent URL corruption** - `normalizeCollections`/`normalizeGlobals` fed `endpoint` straight into `new URL(relativePath, endpoint)`. Without a trailing slash, WHATWG URL resolution drops the last path segment: `new URL('posts', 'https://x/api')` → `https://x/posts`, not `https://x/api/posts`. Both forms of `endpoint` are equally plausible to write, so this now normalizes to a trailing slash once, rather than relying on every caller to remember it.

2. **Crash on network errors** - `fetchEntity`'s 404-tolerance catch did `error.response.status`, which throws when `error.response` is `undefined` - true for any real network-level failure (DNS, connection refused, timeout), not just HTTP error responses. A transient network blip crashed with a confusing `TypeError` instead of a clear `reporter.panic`.

3. **Silent deadlock** - `maxParallelRequests: 0` (or negative) made the throttling interceptor's `PENDING_REQUESTS < maxParallelRequests` check never true. Every request queues forever, no error, the build just hangs. Joi now rejects non-positive values; `createAxiosInstance` also clamps defensively in case that validation is ever bypassed.

4. **Data loss on malformed first page** - a `null`/falsy entry in the *first* page's own `docs` array reached `formatEntity` unfiltered (only pages fetched *beyond* the first were defended against this), crashing and discarding the entire result set for that collection via the outer catch. Same failure class as a bug fixed last session, just on a path that got missed.

5. **The big one: unhandled async in the upload loop** - `createLocalFileNode(context, upload, relationshipIds)` was called without `await`, despite being async (it downloads a file and creates a node). This is both a race condition (`sourceNodes` can resolve before the file node actually exists - a race downstream schema/page-building code can lose) and an unhandled-promise-rejection risk (a failed download crashes the process outside Gatsby's own error handling instead of failing the build cleanly).

## Process note

The async-await test for #5 needed a second pass - my first version passed against the buggy (unawaited) code, but only by timing coincidence (checking `sourceNodesResolved` too early), not because it actually verified awaiting. Tightened it to flush well past the point where a fire-and-forget call would have let `sourceNodes` finish anyway, confirmed it now fails against the bug and passes against the fix.

## Test plan

- [x] `yarn test` - 99 tests pass (10 new/modified across 5 files)
- [x] `tsc --noEmit` - clean build
- [x] Each fix's test manually verified to fail against the pre-fix code
- [ ] CI passes on this PR