### PR TITLE
fix(plugin): add configurable request timeout, make timeouts retryable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Simple config:
 | `globalTypes` | `['nav']` | Specifiy globals to retrive along with any global-specific options. [More](#global-types). |
 | `nodeTransform` | `{ ['myField'] => (myField) => transformMyField(myField) }` | Incorporate functions to transform the value returned for a given Payload field. [More](#node-transform) |
 | `maxParallelRequests` | `10` | Cap requests in flight at once. Unbounded by default. [More](#performance-maxparallelrequests-and-limit). |
+| `requestTimeout` | `30000` | Milliseconds to wait for a request before aborting it. Defaults to `30000` (30s). [More](#requesttimeout). |
 | `retries` | `3` | Retry failed requests using [axios-retry](https://www.npmjs.com/package/axios-retry). |
 
 ### Example
@@ -110,6 +111,32 @@ to set to avoid a regression:
 > was reverted in 1.1.3. If you're on 1.1.2, upgrade to 1.1.3 or later, or set
 > `maxParallelRequests` explicitly to restore your desired concurrency in the
 > meantime.
+
+### `requestTimeout`
+
+Milliseconds to wait for a single request before aborting it. Defaults to
+`30000` (30s).
+
+Without a timeout, a stalled connection (a dropped proxy, a black-holed
+response, a server that accepts the connection but never replies) never
+fails - and if it never fails, it's never retried, and nothing on the client
+side ever gives up on it. The only backstop becomes whatever external timeout
+your CI platform enforces, which is both far slower than useful and outside
+this plugin's control.
+
+```ts
+{
+  // ...
+  requestTimeout: 15000, // fail a stalled request after 15s instead of 30s
+  // ...
+}
+```
+
+If `retries` is also set, a request that failed by timing out is retried, not
+just network errors and 5xx responses - useful against a Payload instance
+that's transiently slow rather than actually down. This is a deliberate
+departure from [axios-retry](https://www.npmjs.com/package/axios-retry)'s own
+default, which explicitly excludes timeouts from its retry logic.
 
 ### Collection Types
 

--- a/plugin/src/__tests__/axios-instance-hung-connection.ts
+++ b/plugin/src/__tests__/axios-instance-hung-connection.ts
@@ -1,0 +1,75 @@
+import { createServer, Server } from "http"
+import { AddressInfo, Socket } from "net"
+import { createAxiosInstance } from "../axios-instance"
+
+describe(`createAxiosInstance against a hung connection`, () => {
+  let server: Server
+  let baseUrl: string
+  let connectionCount: number
+  let sockets: Array<Socket>
+
+  beforeAll((done) => {
+    // Accepts the connection but never writes a response - simulating a
+    // stalled TCP connection, a black-holed response, or a proxy silently
+    // dropping the connection. No RST/FIN is ever sent, so without a client-side
+    // timeout this request would never fail on its own.
+    server = createServer((_req, _res) => {
+      connectionCount += 1
+      // Deliberately never call res.end() / res.write().
+    })
+    sockets = []
+    server.on(`connection`, (socket) => sockets.push(socket))
+    server.listen(0, () => {
+      const address = server.address() as AddressInfo
+      baseUrl = `http://127.0.0.1:${address.port}`
+      done()
+    })
+  })
+
+  afterAll((done) => {
+    // A hung connection that's never responded to may still be open as far
+    // as the server is concerned even after the client has given up (or,
+    // against the pre-fix code with no timeout at all, forever) - destroy
+    // sockets directly rather than relying on graceful close to avoid
+    // hanging the test process on cleanup too.
+    sockets.forEach((socket) => socket.destroy())
+    server.close(done)
+  })
+
+  beforeEach(() => {
+    connectionCount = 0
+  })
+
+  it(
+    `fails fast on a short requestTimeout instead of hanging indefinitely`,
+    async () => {
+      const instance = createAxiosInstance({ apiURL: baseUrl, requestTimeout: 100 })
+
+      const start = Date.now()
+      await expect(instance.get(`/`)).rejects.toMatchObject({ code: `ECONNABORTED` })
+      const elapsedMs = Date.now() - start
+
+      // Comfortably bounded, and nowhere near the 18-minute external CI
+      // timeout this is meant to make unnecessary as a backstop.
+      expect(elapsedMs).toBeLessThan(2000)
+      expect(connectionCount).toEqual(1)
+    },
+    10000
+  )
+
+  it(
+    `retries a timed-out request instead of treating it as non-retryable`,
+    async () => {
+      // axios-retry's own isRetryableError explicitly excludes timeouts by
+      // design - this asserts the plugin's override actually takes effect
+      // against a real timeout, not just against a hand-built error object.
+      const instance = createAxiosInstance({ apiURL: baseUrl, requestTimeout: 100, retries: 2 })
+
+      await expect(instance.get(`/`)).rejects.toMatchObject({ code: `ECONNABORTED` })
+
+      // One initial attempt plus two retries.
+      expect(connectionCount).toEqual(3)
+    },
+    15000
+  )
+})

--- a/plugin/src/__tests__/axios-instance.ts
+++ b/plugin/src/__tests__/axios-instance.ts
@@ -1,5 +1,6 @@
 import axiosRetry from "axios-retry"
 import { createAxiosInstance } from "../axios-instance"
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "../constants"
 
 jest.mock(`axios-retry`, () => {
   const mockAxiosRetry = jest.fn()
@@ -42,13 +43,67 @@ describe(`createAxiosInstance`, () => {
     expect(axiosRetry).toHaveBeenCalledTimes(1)
     const [, config] = (axiosRetry as unknown as jest.Mock).mock.calls[0]
     expect(config.retries).toEqual(3)
-    expect(config.retryCondition).toBe((axiosRetry as any).isRetryableError)
+    expect(config.retryCondition).toBeInstanceOf(Function)
+    // Without this, axios-retry treats the request's timeout as a total budget
+    // across the initial attempt + delay + retry, and silently abandons any
+    // retry of a request that failed by timing out (elapsed time ≈ its own
+    // timeout, so the "remaining" budget it computes is always <= 0) -
+    // regardless of what retryCondition says. See axios-instance-hung-connection.ts
+    // for the real-server test this exists to make actually work end to end.
+    expect(config.shouldResetTimeout).toBe(true)
   })
 
   it(`always attaches a throttling request interceptor`, () => {
     const instance = createAxiosInstance({})
     expect((instance.interceptors.request as any).handlers).toHaveLength(1)
     expect((instance.interceptors.response as any).handlers).toHaveLength(1)
+  })
+
+  describe(`requestTimeout`, () => {
+    it(`defaults the request timeout to DEFAULT_REQUEST_TIMEOUT_MS`, () => {
+      // Without a timeout, a stalled connection never fails - so it never gets
+      // retried, and nothing on the client side ever gives up on it.
+      const instance = createAxiosInstance({})
+      expect(instance.defaults.timeout).toEqual(DEFAULT_REQUEST_TIMEOUT_MS)
+    })
+
+    it(`honors a configured requestTimeout`, () => {
+      const instance = createAxiosInstance({ requestTimeout: 5000 })
+      expect(instance.defaults.timeout).toEqual(5000)
+    })
+
+    it.each([0, -1, -100])(
+      `falls back to the default when requestTimeout is %i (Joi rejects this, but the runtime shouldn't silently disable the timeout either)`,
+      (invalidValue) => {
+        const instance = createAxiosInstance({ requestTimeout: invalidValue })
+        expect(instance.defaults.timeout).toEqual(DEFAULT_REQUEST_TIMEOUT_MS)
+      }
+    )
+  })
+
+  describe(`retryCondition`, () => {
+    it(`treats a timed-out request (ECONNABORTED) as retryable, unlike axios-retry's own default`, () => {
+      // axios-retry's isRetryableError explicitly excludes ECONNABORTED
+      // ("Prevents retrying timed out requests") - for this plugin, a request
+      // that timed out against a possibly transiently-slow Payload instance is
+      // exactly the case we DO want retried, so this overrides that default.
+      ;(axiosRetry.isRetryableError as jest.Mock).mockReturnValue(false)
+      createAxiosInstance({ retries: 3 })
+      const [, config] = (axiosRetry as unknown as jest.Mock).mock.calls[0]
+
+      expect(config.retryCondition({ code: `ECONNABORTED` })).toBe(true)
+    })
+
+    it(`still delegates to axios-retry's own logic for non-timeout errors`, () => {
+      ;(axiosRetry.isRetryableError as jest.Mock).mockReturnValue(false)
+      createAxiosInstance({ retries: 3 })
+      const [, config] = (axiosRetry as unknown as jest.Mock).mock.calls[0]
+
+      expect(config.retryCondition({ response: { status: 404 } })).toBe(false)
+
+      ;(axiosRetry.isRetryableError as jest.Mock).mockReturnValue(true)
+      expect(config.retryCondition({ response: { status: 503 } })).toBe(true)
+    })
   })
 
   describe(`throttling`, () => {

--- a/plugin/src/__tests__/plugin-options-schema.ts
+++ b/plugin/src/__tests__/plugin-options-schema.ts
@@ -102,4 +102,35 @@ describe(`pluginOptionsSchema`, () => {
     expect(isValid).toBe(true)
     expect(errors).toEqual([])
   })
+  it(`rejects a requestTimeout of 0, which would disable the request timeout entirely`, async () => {
+    const options = {
+      endpoint: `http://localhost:4000/graphql`,
+      requestTimeout: 0,
+    }
+
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, options)
+
+    expect(isValid).toBe(false)
+  })
+  it(`rejects a negative requestTimeout`, async () => {
+    const options = {
+      endpoint: `http://localhost:4000/graphql`,
+      requestTimeout: -1,
+    }
+
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, options)
+
+    expect(isValid).toBe(false)
+  })
+  it(`accepts a positive integer requestTimeout`, async () => {
+    const options = {
+      endpoint: `http://localhost:4000/graphql`,
+      requestTimeout: 5000,
+    }
+
+    const { isValid, errors } = await testPluginOptionsSchema(pluginOptionsSchema, options)
+
+    expect(isValid).toBe(true)
+    expect(errors).toEqual([])
+  })
 })

--- a/plugin/src/axios-instance.ts
+++ b/plugin/src/axios-instance.ts
@@ -1,5 +1,18 @@
 import axios from "axios"
 import axiosRetry from "axios-retry"
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "./constants"
+
+/**
+ * axios-retry's own isRetryableError explicitly excludes ECONNABORTED (timeout)
+ * errors - "Prevents retrying timed out requests" - a deliberate default on its
+ * part. For this plugin, a request that timed out against a possibly
+ * transiently-slow Payload instance is exactly the case we want retried, so
+ * this is a superset: everything axios-retry's own logic treats as retryable,
+ * plus timeouts.
+ */
+const isRetryableIncludingTimeouts = (error): boolean => {
+  return error.code === `ECONNABORTED` || axiosRetry.isRetryableError(error)
+}
 
 /**
  * Inspiration from:
@@ -43,6 +56,13 @@ export const createAxiosInstance = (pluginConfig) => {
     // origin API or the build machine, at the cost of wall-clock time — see the
     // README for the tradeoff.
     maxParallelRequests: configuredMaxParallelRequests = Number.POSITIVE_INFINITY,
+    // Without a timeout, a stalled connection (no RST/FIN, a black-holed
+    // response, a proxy silently dropping the connection) never fails - so it
+    // never gets retried, and nothing on the client side ever gives up on it.
+    // The only backstop becomes whatever external timeout a CI platform
+    // enforces, which is both far too long to be useful and outside this
+    // plugin's control.
+    requestTimeout: configuredRequestTimeout = DEFAULT_REQUEST_TIMEOUT_MS,
     accessToken,
     accessCollectionSlug,
     apiURL,
@@ -57,6 +77,14 @@ export const createAxiosInstance = (pluginConfig) => {
       ? configuredMaxParallelRequests
       : Number.POSITIVE_INFINITY
 
+  // Same defense-in-depth as maxParallelRequests above: a value of 0 is
+  // axios's own convention for "no timeout", which would silently reintroduce
+  // the exact hang this option exists to prevent.
+  const requestTimeout =
+    isFinite(configuredRequestTimeout) && configuredRequestTimeout >= 1
+      ? configuredRequestTimeout
+      : DEFAULT_REQUEST_TIMEOUT_MS
+
   const headers: { [key: string]: string } = {}
 
   if (accessToken) {
@@ -66,6 +94,7 @@ export const createAxiosInstance = (pluginConfig) => {
   const instance = axios.create({
     baseURL: apiURL,
     headers,
+    timeout: requestTimeout,
   })
   if (pluginConfig.retries) {
     // https://github.com/softonic/axios-retry/issues/87
@@ -78,8 +107,19 @@ export const createAxiosInstance = (pluginConfig) => {
     axiosRetry(instance, {
       retries: pluginConfig.retries,
       retryDelay,
-      // retry on Network Error & 5xx responses
-      retryCondition: axiosRetry.isRetryableError,
+      // Retry on network errors, 5xx responses, and timeouts (see
+      // isRetryableIncludingTimeouts above for why timeouts are included).
+      retryCondition: isRetryableIncludingTimeouts,
+      // Without this, axios-retry treats the original request's `timeout` as a
+      // TOTAL budget shared across the initial attempt + delay + retry, not a
+      // per-attempt timeout: it computes `config.timeout - elapsedTime - delay`
+      // as the "remaining" timeout for the retry, and silently abandons the
+      // retry if that's <= 0. A request that failed BY timing out has elapsed
+      // time ≈ its own timeout, so that's always negative - meaning a timed-out
+      // request could never actually be retried regardless of retryCondition,
+      // even with the override above. shouldResetTimeout gives each retry its
+      // own fresh timeout instead.
+      shouldResetTimeout: true,
     })
   }
 

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -20,6 +20,15 @@ export const PAGE_COUNT_WARNING_THRESHOLD = 20
 export const PROGRESS_LOG_INTERVAL = 10
 
 /**
+ * Default request timeout in milliseconds (see axios-instance.ts). Without a
+ * timeout, a stalled connection never fails, so it's never retried and the
+ * build never gives up on it - the only backstop becomes whatever external
+ * timeout a CI platform enforces, which is both far too long to be useful and
+ * outside this plugin's control.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30000
+
+/**
  * The IDs for your errors can be arbitrary (since they are scoped to your plugin), but it's good practice to have a system for them.
  * For example, you could start all third-party API errors with 1000x, all transformation errors with 2000x, etc.
  */

--- a/plugin/src/plugin-options-schema.ts
+++ b/plugin/src/plugin-options-schema.ts
@@ -118,6 +118,16 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     // A value of 0 or below would deadlock the throttling interceptor - every
     // request would wait forever for a free slot that can never exist.
     maxParallelRequests: Joi.number().integer().min(1),
+    /**
+     * Optional. Milliseconds to wait for a request before aborting it. Defaults
+     * to a sane value (see DEFAULT_REQUEST_TIMEOUT_MS in constants.ts) rather
+     * than no timeout at all - without one, a stalled connection (no RST/FIN,
+     * a black-holed response, a proxy silently dropping the connection) never
+     * fails, so it never gets retried and never gives up: nothing on the
+     * client side ever moves on from it. A value of 0 would disable the
+     * timeout entirely (axios's own convention), reintroducing that hang.
+     */
+    requestTimeout: Joi.number().integer().min(1),
     // Optional. Retry requests using https://www.npmjs.com/package/axios-retry.
     retries: Joi.number(),
     fallbackLocale: Joi.string(),


### PR DESCRIPTION
## Summary

`createAxiosInstance` built the shared axios instance with no `timeout` option at all. `axios-retry` is wired up, but that only triggers once a request actually *fails* — a stalled TCP connection (no RST/FIN, a black-holed response, a proxy silently dropping the connection) never fails, so axios-retry never sees it and never retries. Nothing on the client side ever gave up on it; the only backstop was whatever external timeout the CI platform enforced.

**Reported real-world impact**: a Gatsby build fired 13 concurrent requests to Payload via this plugin (well within `maxParallelRequests`, confirmed not the zero/negative deadlock fixed in #111), and every one went silent for the entire remainder of the build, until the CI platform's own 18-minute process timeout force-killed it.

## Changes

- Adds a `requestTimeout` plugin option, default 30s, following the same validation pattern as `maxParallelRequests` from #111: Joi rejects non-positive values (0 is axios's own convention for "no timeout" and would silently reintroduce the hang), and `createAxiosInstance` clamps defensively in case that validation is ever bypassed.
- A timed-out request produces an `ECONNABORTED` error, which axios-retry's own `isRetryableError` **explicitly excludes** ("Prevents retrying timed out requests" — see its source). Overrode this with a superset that includes timeouts, since a request timing out against a possibly transiently-slow Payload instance is exactly the case this plugin wants retried.
- **A second, more subtle fix was needed to actually make that work**: even with the `retryCondition` override, axios-retry treats the request's original `timeout` as a *total* budget shared across the initial attempt + delay + retry (`config.timeout - elapsedTime - delay`) unless `shouldResetTimeout` is set. A request that failed *by* timing out has elapsed time ≈ its own timeout, so that "remaining budget" is always negative — meaning a timed-out request could never actually be retried, regardless of what `retryCondition` says. I found this by writing the real-server integration test below and watching it report 1 connection instead of 3 even though `retryCondition` was returning `true`. Fixed by setting `shouldResetTimeout: true`.

## Tests

Added a real HTTP server that accepts the connection and never responds (no mocking — this needs real `axios-retry` behavior, so it's a separate unmocked test file):
- Confirms a request against it fails in ~150ms instead of hanging.
- Confirms retries actually fire off the back of a *real* timeout (3 total connections: 1 initial + 2 retries), not just a hand-built error object.

I verified this test file hangs indefinitely against the pre-fix code (no timeout at all) by directly observing it — had to kill the background process after 2+ minutes since Jest's own per-test timeout doesn't reliably abort in-flight requests when nothing on the client side ever gives up. Also added fast mocked-`axios-retry` unit tests for the default/custom/invalid `requestTimeout` handling and the `retryCondition`/`shouldResetTimeout` config, so most of this is covered without needing the slow real-server test on every run.

## Test plan

- [x] `yarn test` — 111 tests pass (9 test suites)
- [x] `tsc --noEmit` — clean build
- [x] Manually confirmed the real-server test hangs against the pre-fix code and passes (~150ms / ~8s with retries) against the fix
- [ ] CI passes on this PR